### PR TITLE
Implement Safe Zone Crafting Restriction and RNG Search System

### DIFF
--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -30,7 +30,11 @@ public class GameLoop {
 
             switch (command.toLowerCase()) {
                 case "craft":
-                    state.crystals = CraftingSystem.craftWeapon(player, state.crystals);
+                    if (state.inSafeZone) {
+                        state.crystals = CraftingSystem.craftWeapon(player, state.crystals);
+                    } else {
+                        TextEffect.typeWriter("⚒️ You can only craft while inside a Safe Zone.", 50);
+                    }
                     break;
 
                 case "search":
@@ -43,7 +47,7 @@ public class GameLoop {
 
                 case "move":
                     ExplorationSystem.handleMove(player, scanner, rand, state,
-                        () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state));
+                            () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state));
                     break;
 
                 default:

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -44,8 +44,11 @@ public class GameLoop {
                     break;
 
                 case "search":
-                    // 🆕 Allow search anywhere
-                    rpg.systems.SafeZoneSystem.searchSafeZone(player, state);
+                    if (state.inSafeZone) {
+                        rpg.systems.SafeZoneSystem.searchSafeZone(player, state);
+                    } else {
+                        rpg.systems.SearchSystem.search(state);
+                    }
                     break;
 
                 case "status":

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -25,7 +25,13 @@ public class GameLoop {
         boolean running = true;
 
         while (running) {
-            System.out.print("> (craft / search / status / move): ");
+            // 🆕 Dynamic prompt
+            if (state.inSafeZone) {
+                System.out.print("> (craft / search / status / move): ");
+            } else {
+                System.out.print("> (search / status / move): ");
+            }
+
             String command = scanner.nextLine();
 
             switch (command.toLowerCase()) {
@@ -38,6 +44,7 @@ public class GameLoop {
                     break;
 
                 case "search":
+                    // 🆕 Allow search anywhere
                     rpg.systems.SafeZoneSystem.searchSafeZone(player, state);
                     break;
 

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -7,4 +7,5 @@ public class GameState {
     public int meat = 0;
     public int revivalPotions = 0;
     public Enemy currentZoneBoss; 
+    public boolean inSafeZone = false;
 }

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -30,6 +30,8 @@ public class Tutorial {
         TextEffect.typeWriter("[Narrator] You feel weak. You need food and a weapon.", 80);
         TextEffect.typeWriter("Objective: Find food + find a weapon.", 80);
 
+        TextEffect.typeWriter("[Narrator] Remember: crafting can only be done while inside a Safe Zone.", 80);
+
         boolean hasCrystal = false;
         boolean hasPencil = false;
         boolean awake = true;

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -11,7 +11,6 @@ import rpg.world.WorldData;
 
 public class ExplorationSystem {
 
-
     public static void handleMove(
         Player player,
         Scanner scanner,
@@ -19,43 +18,52 @@ public class ExplorationSystem {
         GameState state,
         Runnable safeZoneAction
     ) {
-    TextEffect.typeWriter("Do you move forward or backward?", 40);
-    System.out.print("> ");
-    String dir = scanner.nextLine();
+        TextEffect.typeWriter("Do you move forward or backward?", 40);
+        System.out.print("> ");
+        String dir = scanner.nextLine();
 
-    ZoneConfig zone = WorldData.getZone(state.zone);
-    state.currentZoneBoss = zone.boss;
+        ZoneConfig zone = WorldData.getZone(state.zone);
+        state.currentZoneBoss = zone.boss;
 
-    if (dir.equalsIgnoreCase("backward")) {
-        safeZoneAction.run();
-    } else if (dir.equalsIgnoreCase("forward")) {
-        state.forwardSteps++;
-        if (state.forwardSteps >= 5) {
-            CombatSystem combat = new CombatSystem(state);
-            boolean win = combat.startCombat(player, zone.boss);
-            if (win) {
-                TextEffect.typeWriter("🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
-                state.zone++;
-                state.forwardSteps = 0;
-                safeZoneAction.run();
+        if (dir.equalsIgnoreCase("backward")) {
+            // 🆕 mark safe zone
+            state.inSafeZone = true;
+            safeZoneAction.run();
+
+        } else if (dir.equalsIgnoreCase("forward")) {
+            // 🆕 leaving safe zone
+            state.inSafeZone = false;
+            state.forwardSteps++;
+
+            if (state.forwardSteps >= 5) {
+                CombatSystem combat = new CombatSystem(state);
+                boolean win = combat.startCombat(player, zone.boss);
+                if (win) {
+                    TextEffect.typeWriter("🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+                    state.zone++;
+                    state.forwardSteps = 0;
+                    // 🆕 entering new safe zone
+                    state.inSafeZone = true;
+                    safeZoneAction.run();
+                } else {
+                    TextEffect.typeWriter("You awaken back at the safe zone...", 60);
+                    state.inSafeZone = true;
+                    safeZoneAction.run();
+                }
             } else {
-                TextEffect.typeWriter("You awaken back at the safe zone...", 60);
-                safeZoneAction.run();
+                int roll = rand.nextInt(100);
+                Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
+                CombatSystem combat = new CombatSystem(state);
+                if (combat.startCombat(player, mob)) {
+                    int crystalDrop = 1 + rand.nextInt(2);
+                    int meatDrop = rand.nextInt(2);
+                    state.crystals += crystalDrop;
+                    state.meat += meatDrop;
+                    TextEffect.typeWriter("Loot: +" + crystalDrop + " Crystals, +" + meatDrop + " Meat.", 50);
+                }
             }
         } else {
-            int roll = rand.nextInt(100);
-            Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
-            CombatSystem combat = new CombatSystem(state);
-            if (combat.startCombat(player, mob)) {
-                int crystalDrop = 1 + rand.nextInt(2);
-                int meatDrop = rand.nextInt(2);
-                state.crystals += crystalDrop;
-                state.meat += meatDrop;
-                TextEffect.typeWriter("Loot: +" + crystalDrop + " Crystals, +" + meatDrop + " Meat.", 50);
-            }
+            TextEffect.typeWriter("Invalid direction.", 40);
         }
-    } else {
-        TextEffect.typeWriter("Invalid direction.", 40);
     }
-    }
-}   
+}

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -7,12 +7,12 @@ import rpg.game.GameState;
 public class SafeZoneSystem {
     public static void enterSafeZone(Player player, GameState state) {
         player.healFull();
+        state.inSafeZone = true; // 🆕 mark safe zone
         TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
         TextEffect.typeWriter("Your stats have been fully restored.", 60);
     }
 
     public static void searchSafeZone(Player player, GameState state) {
-        // Placeholder for zone-based search logic; safe to keep empty for now
         TextEffect.typeWriter("You search around but find nothing useful.", 60);
     }
 }

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -1,0 +1,24 @@
+package rpg.systems;
+
+import java.util.Random;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+
+public class SearchSystem {
+    private static Random rand = new Random();
+
+    public static void search(GameState state) {
+        int roll = rand.nextInt(100);
+        if (roll < 40) {
+            state.crystals++;
+            TextEffect.typeWriter("You scavenge the area and find a Shard!", 50);
+        } else if (roll < 70) {
+            state.meat++;
+            TextEffect.typeWriter("You hunt around and find some Meat.", 50);
+        } else if (roll < 90) {
+            TextEffect.typeWriter("You discover a small vial of medicine — it might help later.", 50);
+        } else {
+            TextEffect.typeWriter("You search the area but find nothing of value.", 50);
+        }
+    }
+}


### PR DESCRIPTION
## PR Title
Restrict Crafting to Safe Zones and Add RNG Search

## Description
- Added `inSafeZone` flag to `GameState`
- Crafting now only works inside Safe Zones
- Dynamic command menu:
  - Safe Zone → `(craft / search / status / move)`
  - Outside → `(search / status / move)`
- Search behavior:
  - Safe Zone 1 → scripted tutorial search
  - Other Safe Zones → nothing useful
  - Outside Safe Zones → RNG loot:
    - 40% Shard (+1 crystal)
    - 30% Meat (+1 meat)
    - 20% Flavor text for medicine
    - 10% Nothing
