### PR TITLE
Refactor Safe Zone Flow, Global Shop Access, and Status/Shop Enhancements

### DIFF
--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -9,4 +9,6 @@ public class GameState {
     public int revivalPotions = 0;
     public Enemy currentZoneBoss; 
     public boolean inSafeZone = false;
+    public boolean hasStageWeapon1 = false;
+    public boolean hasStageWeapon2 = false;
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -1,7 +1,9 @@
 package rpg.game;
 
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Set;
+import java.util.Map;
 import rpg.characters.Enemy;
 
 public class GameState {
@@ -16,12 +18,11 @@ public class GameState {
 
     // ✅ Track crafted stage weapons
     public boolean hasStageWeapon1 = false;
-    public boolean hasStageWeapon2 = false;\
-
+    public boolean hasStageWeapon2 = false;
 
     // ✅ Track unlocked blueprints
     public Set<String> unlockedRecipes = new HashSet<>();
 
-    public boolean hasCrystalSwordRecipeItem = false; // obtained via drop/search
-
+    // ✅ Track obtained recipe items
+    public Map<String, Boolean> recipeItems = new HashMap<>();
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -1,5 +1,9 @@
 package rpg.game;
+
+import java.util.HashSet;
+import java.util.Set;
 import rpg.characters.Enemy;
+
 public class GameState {
     public int zone = 1;
     public int forwardSteps = 0;
@@ -9,6 +13,15 @@ public class GameState {
     public int revivalPotions = 0;
     public Enemy currentZoneBoss; 
     public boolean inSafeZone = false;
+
+    // ✅ Track crafted stage weapons
     public boolean hasStageWeapon1 = false;
-    public boolean hasStageWeapon2 = false;
+    public boolean hasStageWeapon2 = false;\
+
+
+    // ✅ Track unlocked blueprints
+    public Set<String> unlockedRecipes = new HashSet<>();
+
+    public boolean hasCrystalSwordRecipeItem = false; // obtained via drop/search
+
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -25,4 +25,7 @@ public class GameState {
 
     // ✅ Track obtained recipe items
     public Map<String, Boolean> recipeItems = new HashMap<>();
+
+    public boolean shopUnlocked = false;
+
 }

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -27,7 +27,9 @@ public class Tutorial {
     }
 
     public void start() {
-        TextEffect.typeWriter("[Narrator] You feel weak. You need food and a weapon.", 80);
+        TextEffect.typeWriter("🏫 [Narrator] You awaken on the School Rooftop — your first Safe Zone.", 80);
+        TextEffect.typeWriter("The world below is silent, statues of your classmates frozen in time.", 80);
+        TextEffect.typeWriter("You feel weak. You need food and a weapon.", 80);
         TextEffect.typeWriter("Objective: Find food + find a weapon.", 80);
 
         TextEffect.typeWriter("[Narrator] Remember: crafting can only be done while inside a Safe Zone.", 80);
@@ -43,7 +45,7 @@ public class Tutorial {
             switch (command.toLowerCase()) {
                 case "search":
                     if (!hasCrystal && !hasPencil) {
-                        TextEffect.typeWriter("You search the ruined classroom...", 60);
+                        TextEffect.typeWriter("You search the school rooftop...", 60);
                         TextEffect.typeWriter("You found: 1 Crystal, 1 Crystal Shard, and a Pencil.", 60);
 
                         // 🆕 Narrator explains the difference

--- a/src/rpg/items/Blueprint.java
+++ b/src/rpg/items/Blueprint.java
@@ -1,0 +1,19 @@
+package rpg.items;
+
+public class Blueprint {
+    private String name;
+    private String unlocksRecipe;
+
+    public Blueprint(String name, String unlocksRecipe) {
+        this.name = name;
+        this.unlocksRecipe = unlocksRecipe;
+    }
+
+    public String getName() { return name; }
+    public String getUnlocksRecipe() { return unlocksRecipe; }
+
+    @Override
+    public String toString() {
+        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ")";
+    }
+}

--- a/src/rpg/items/Blueprint.java
+++ b/src/rpg/items/Blueprint.java
@@ -3,17 +3,20 @@ package rpg.items;
 public class Blueprint {
     private String name;
     private String unlocksRecipe;
+    private int price;
 
-    public Blueprint(String name, String unlocksRecipe) {
+    public Blueprint(String name, String unlocksRecipe, int price) {
         this.name = name;
         this.unlocksRecipe = unlocksRecipe;
+        this.price = price;
     }
 
     public String getName() { return name; }
     public String getUnlocksRecipe() { return unlocksRecipe; }
+    public int getPrice() { return price; }
 
     @Override
     public String toString() {
-        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ")";
+        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ", Price: " + price + " Shards)";
     }
 }

--- a/src/rpg/items/Weapon.java
+++ b/src/rpg/items/Weapon.java
@@ -1,19 +1,41 @@
 package rpg.items;
 
+import java.util.Random;
+
 public class Weapon {
     private String name;
-    private int damage;
+    private int minDamage;
+    private int maxDamage;
+    private double critChance;   // e.g. 0.1 = 10% chance
+    private double critMultiplier; // e.g. 2.0 = double damage
 
-    public Weapon(String name, int damage) {
+    public Weapon(String name, int minDamage, int maxDamage, double critChance, double critMultiplier) {
         this.name = name;
-        this.damage = damage;
+        this.minDamage = minDamage;
+        this.maxDamage = maxDamage;
+        this.critChance = critChance;
+        this.critMultiplier = critMultiplier;
     }
 
     public String getName() { return name; }
-    public int getDamage() { return damage; }
+    public int getMinDamage() { return minDamage; }
+    public int getMaxDamage() { return maxDamage; }
+    public double getCritChance() { return critChance; }
+    public double getCritMultiplier() { return critMultiplier; }
+
+    // 🎲 Roll damage dynamically
+    public int rollDamage(Random rand) {
+        int dmg = rand.nextInt(maxDamage - minDamage + 1) + minDamage;
+        if (rand.nextDouble() < critChance) {
+            System.out.println("💥 Critical Hit!");
+            dmg = (int)(dmg * critMultiplier);
+        }
+        return dmg;
+    }
 
     @Override
     public String toString() {
-        return name + " (Damage: " + damage + ")";
+        return name + " (Damage: " + minDamage + "-" + maxDamage + 
+               ", Crit: " + (int)(critChance * 100) + "% x" + critMultiplier + ")";
     }
 }

--- a/src/rpg/systems/BossGateSystem.java
+++ b/src/rpg/systems/BossGateSystem.java
@@ -1,0 +1,29 @@
+package rpg.systems;
+
+import rpg.characters.Player;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+
+public class BossGateSystem {
+
+    public static boolean canFightBoss(GameState state, Player player, Runnable safeZoneAction) {
+        // Stage 1 requirement
+        if (state.zone == 1 && !state.stage1WeaponCrafted) {
+            TextEffect.typeWriter("You sense overwhelming danger ahead. You must forge the Crystal Dagger before facing this boss.", 70);
+            state.inSafeZone = true;
+            safeZoneAction.run();
+            return false;
+        }
+
+        // Stage 2 requirement
+        if (state.zone == 2 && !state.stage2WeaponCrafted) {
+            TextEffect.typeWriter("The path is blocked by a powerful aura. Only the Crystal Sword can pierce it.", 70);
+            state.inSafeZone = true;
+            safeZoneAction.run();
+            return false;
+        }
+
+        // ✅ Add more stages as needed
+        return true;
+    }
+}

--- a/src/rpg/systems/BossGateSystem.java
+++ b/src/rpg/systems/BossGateSystem.java
@@ -7,15 +7,7 @@ import rpg.game.GameState;
 public class BossGateSystem {
 
     public static boolean canFightBoss(GameState state, Player player, Runnable safeZoneAction) {
-        // Stage 1 requirement
-        if (state.zone == 1 && !state.stage1WeaponCrafted) {
-            TextEffect.typeWriter("You sense overwhelming danger ahead. You must forge the Crystal Dagger before facing this boss.", 70);
-            state.inSafeZone = true;
-            safeZoneAction.run();
-            return false;
-        }
-
-        // Stage 2 requirement
+        // Stage 2 requirement (Crystal Sword)
         if (state.zone == 2 && !state.stage2WeaponCrafted) {
             TextEffect.typeWriter("The path is blocked by a powerful aura. Only the Crystal Sword can pierce it.", 70);
             state.inSafeZone = true;

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -3,24 +3,19 @@ package rpg.systems;
 import rpg.characters.Player;
 import rpg.items.Weapon;
 import rpg.utils.TextEffect;
+import rpg.game.GameState;
 
 public class CraftingSystem {
-public static int craftWeapon(Player player, int crystals, GameState state) {
-    if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
-        crystals -= 3;
-        player.equipWeapon(new Weapon("Crystal Dagger", 20));
-        state.stage1WeaponCrafted = true; // ✅ mark stage 1 weapon crafted
-        TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
-    } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
-        crystals -= 5;
-        player.equipWeapon(new Weapon("Crystal Sword", 35));
-        state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
-        TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
-    } else {
-        TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+    public static int craftWeapon(Player player, int crystals, GameState state) {
+        // Upgrade Pencil Blade → Crystal Sword
+        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 5) {
+            crystals -= 5;
+            player.equipWeapon(new Weapon("Crystal Sword", 35));
+            state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+            TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+        } else {
+            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+        }
+        return crystals;
     }
-    return crystals;
 }
-
-}
-

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -5,19 +5,22 @@ import rpg.items.Weapon;
 import rpg.utils.TextEffect;
 
 public class CraftingSystem {
-    public static int craftWeapon(Player player, int crystals) {
-        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
-            crystals -= 3;
-            player.equipWeapon(new Weapon("Crystal Dagger", 20));
-            TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
-        } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
-            crystals -= 5;
-            player.equipWeapon(new Weapon("Crystal Sword", 35));
-            TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
-        } else {
-            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
-        }
-        return crystals;
+public static int craftWeapon(Player player, int crystals, GameState state) {
+    if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
+        crystals -= 3;
+        player.equipWeapon(new Weapon("Crystal Dagger", 20));
+        state.stage1WeaponCrafted = true; // ✅ mark stage 1 weapon crafted
+        TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
+    } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
+        crystals -= 5;
+        player.equipWeapon(new Weapon("Crystal Sword", 35));
+        state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+        TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+    } else {
+        TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
     }
+    return crystals;
+}
+
 }
 

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -7,24 +7,25 @@ import rpg.game.GameState;
 
 public class CraftingSystem {
     public static int craftWeapon(Player player, int crystals, GameState state) {
-        // Upgrade Pencil Blade → Crystal Sword (requires blueprint)
-        if (player.getWeapon() != null
-                && player.getWeapon().getName().equals("Pencil Blade")
-                && crystals >= 5
-                && state.unlockedRecipes.contains("Crystal Sword")
-                && state.hasCrystalSwordRecipeItem) {
+        // Example: Pencil Blade → Crystal Sword
+        String target = "Crystal Sword";
+
+        if (player.getWeapon() != null 
+            && player.getWeapon().getName().equals("Pencil Blade") 
+            && crystals >= 5 
+            && state.unlockedRecipes.contains(target) 
+            && state.recipeItems.getOrDefault(target, false)) {
 
             crystals -= 5;
-            player.equipWeapon(new Weapon("Crystal Sword", 35));
+            player.equipWeapon(new Weapon("Crystal Sword", 20, 35, 0.10, 2.0));
             state.hasStageWeapon2 = true;
             TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
 
-        } else if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+        } else if (state.unlockedRecipes.contains(target) && !state.recipeItems.getOrDefault(target, false)) {
             TextEffect.typeWriter("You know the blueprint, but you haven’t found the recipe item yet.", 60);
         } else {
             TextEffect.typeWriter("You don’t have the requirements to craft this weapon.", 60);
         }
-
         return crystals;
     }
 }

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -7,15 +7,24 @@ import rpg.game.GameState;
 
 public class CraftingSystem {
     public static int craftWeapon(Player player, int crystals, GameState state) {
-        // Upgrade Pencil Blade → Crystal Sword
-        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 5) {
+        // Upgrade Pencil Blade → Crystal Sword (requires blueprint)
+        if (player.getWeapon() != null
+                && player.getWeapon().getName().equals("Pencil Blade")
+                && crystals >= 5
+                && state.unlockedRecipes.contains("Crystal Sword")
+                && state.hasCrystalSwordRecipeItem) {
+
             crystals -= 5;
             player.equipWeapon(new Weapon("Crystal Sword", 35));
-            state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+            state.hasStageWeapon2 = true;
             TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+
+        } else if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            TextEffect.typeWriter("You know the blueprint, but you haven’t found the recipe item yet.", 60);
         } else {
-            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+            TextEffect.typeWriter("You don’t have the requirements to craft this weapon.", 60);
         }
+
         return crystals;
     }
 }

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -36,6 +36,12 @@ public class ExplorationSystem {
             state.forwardSteps++;
 
             if (state.forwardSteps >= 5) {
+                // 🛡️ Check if player can fight boss (weapon requirement)
+                if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
+                    return; // stop here if requirement not met
+                }
+
+                // ✅ If requirement met, proceed to boss fight
                 CombatSystem combat = new CombatSystem(state);
                 boolean win = combat.startCombat(player, zone.boss);
                 if (win) {
@@ -50,6 +56,7 @@ public class ExplorationSystem {
                     safeZoneAction.run();
                 }
             } else {
+                // Random mob encounter
                 Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
                 CombatSystem combat = new CombatSystem(state);
                 if (combat.startCombat(player, mob)) {

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -8,9 +8,9 @@ public class LootSystem {
     private static Random rand = new Random();
 
     public static void dropLoot(GameState state) {
-        int crystalDrop = (rand.nextInt(100) < 10) ? 1 : 0; // 10% chance
-        int meatDrop = rand.nextInt(2);                     // 0–1
-        int shardDrop = 1 + rand.nextInt(3);                // 1–3
+        int crystalDrop = (rand.nextInt(100) < 10) ? 1 : 0;
+        int meatDrop = rand.nextInt(2);
+        int shardDrop = 1 + rand.nextInt(3);
 
         state.crystals += crystalDrop;
         state.meat += meatDrop;
@@ -21,11 +21,13 @@ public class LootSystem {
         if (crystalDrop > 0) lootMsg.append(", +" + crystalDrop + " Crystal");
         if (meatDrop > 0) lootMsg.append(", +" + meatDrop + " Meat");
 
-        // ✅ Check for recipe item drop (only if blueprint unlocked)
-        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
-            if (rand.nextInt(100) < 15) { // 15% chance from loot
-                state.hasCrystalSwordRecipeItem = true;
-                lootMsg.append(", ✨ Crystal Sword Recipe");
+        // ✅ Check for recipe item drop
+        for (String recipe : state.unlockedRecipes) {
+            if (!state.recipeItems.getOrDefault(recipe, false)) {
+                if (rand.nextInt(100) < 15) { // 15% chance
+                    state.recipeItems.put(recipe, true);
+                    lootMsg.append(", ✨ " + recipe + " Recipe");
+                }
             }
         }
 

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -21,6 +21,14 @@ public class LootSystem {
         if (crystalDrop > 0) lootMsg.append(", +" + crystalDrop + " Crystal");
         if (meatDrop > 0) lootMsg.append(", +" + meatDrop + " Meat");
 
+        // ✅ Check for recipe item drop (only if blueprint unlocked)
+        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            if (rand.nextInt(100) < 15) { // 15% chance from loot
+                state.hasCrystalSwordRecipeItem = true;
+                lootMsg.append(", ✨ Crystal Sword Recipe");
+            }
+        }
+
         TextEffect.typeWriter(lootMsg.toString(), 50);
     }
 }

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -1,15 +1,68 @@
 package rpg.systems;
 
+import java.util.Scanner;
 import rpg.characters.Player;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
 
 public class SafeZoneSystem {
-    public static void enterSafeZone(Player player, GameState state) {
+
+    public static void enterSafeZone(Player player, GameState state, Scanner scanner) {
+        // ✅ Always heal
         player.healFull();
-        state.inSafeZone = true; // 🆕 mark safe zone
+        state.inSafeZone = true;
         TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
         TextEffect.typeWriter("Your stats have been fully restored.", 60);
+
+        // ✅ Zone-specific interactions
+        switch (state.zone) {
+            case 1:
+                zone1Interaction();
+                break;
+            case 2:
+                zone2Interaction(state, scanner);
+                break;
+            default:
+                genericInteraction(state, scanner);
+        }
+    }
+
+    private static void zone1Interaction() {
+        TextEffect.typeWriter("This place feels calm. You take a moment to breathe.", 60);
+    }
+
+    private static void zone2Interaction(GameState state, Scanner scanner) {
+        // Step 1: Story NPC
+        TextEffect.typeWriter("[Elder Scholar] Traveler, the guardian ahead cannot be harmed by ordinary steel.", 60);
+        TextEffect.typeWriter("Seek the knowledge of forging — only then will you stand a chance.", 60);
+
+        // Step 2: Shop NPC introduction
+        TextEffect.typeWriter("\nA merchant approaches you.", 60);
+        TextEffect.typeWriter("[Merchant] Greetings! I deal in blueprints and secrets of crafting.", 60);
+        TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
+
+        // ✅ Unlock shop globally
+        state.shopUnlocked = true;
+
+        // Offer immediate shop access
+        System.out.print("Do you want to browse the shop now? (yes/no): ");
+        String choice = scanner.nextLine();
+        if (choice.equalsIgnoreCase("yes")) {
+            ShopSystem.openShop(state, scanner);
+        }
+    }
+
+    private static void genericInteraction(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("You rest safely here.", 60);
+
+        // ✅ If shop unlocked, allow access
+        if (state.shopUnlocked) {
+            System.out.print("Do you want to visit the shop? (yes/no): ");
+            String choice = scanner.nextLine();
+            if (choice.equalsIgnoreCase("yes")) {
+                ShopSystem.openShop(state, scanner);
+            }
+        }
     }
 
     public static void searchSafeZone(Player player, GameState state) {

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -27,8 +27,8 @@ public class SafeZoneSystem {
         }
     }
 
-    private static void zone1Interaction() {
-        TextEffect.typeWriter("This place feels calm. You take a moment to breathe.", 60);
+    private static void zone1Interaction(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("You rest on the School Rooftop. Your stats are restored.", 60);
     }
 
     private static void zone2Interaction(GameState state, Scanner scanner) {

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -13,23 +13,22 @@ public class SearchSystem {
         if (roll < 40) {
             state.shards++;
             TextEffect.typeWriter("You scavenge the area and find a Shard!", 50);
-
         } else if (roll < 70) {
             state.meat++;
             TextEffect.typeWriter("You hunt around and find some Meat.", 50);
-
         } else if (roll < 90) {
             TextEffect.typeWriter("You discover a small vial of medicine — it might help later.", 50);
-
         } else {
             TextEffect.typeWriter("You search the area but find nothing of value.", 50);
         }
 
         // ✅ Chance to find recipe item if blueprint unlocked
-        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
-            if (rand.nextInt(100) < 10) { // 10% chance from searching
-                state.hasCrystalSwordRecipeItem = true;
-                TextEffect.typeWriter("✨ While searching, you uncover the Crystal Sword Recipe!", 60);
+        for (String recipe : state.unlockedRecipes) {
+            if (!state.recipeItems.getOrDefault(recipe, false)) {
+                if (rand.nextInt(100) < 10) { // 10% chance
+                    state.recipeItems.put(recipe, true);
+                    TextEffect.typeWriter("✨ While searching, you uncover the " + recipe + " Recipe!", 60);
+                }
             }
         }
     }

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -9,16 +9,28 @@ public class SearchSystem {
 
     public static void search(GameState state) {
         int roll = rand.nextInt(100);
+
         if (roll < 40) {
-            state.crystals++;
+            state.shards++;
             TextEffect.typeWriter("You scavenge the area and find a Shard!", 50);
+
         } else if (roll < 70) {
             state.meat++;
             TextEffect.typeWriter("You hunt around and find some Meat.", 50);
+
         } else if (roll < 90) {
             TextEffect.typeWriter("You discover a small vial of medicine — it might help later.", 50);
+
         } else {
             TextEffect.typeWriter("You search the area but find nothing of value.", 50);
+        }
+
+        // ✅ Chance to find recipe item if blueprint unlocked
+        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            if (rand.nextInt(100) < 10) { // 10% chance from searching
+                state.hasCrystalSwordRecipeItem = true;
+                TextEffect.typeWriter("✨ While searching, you uncover the Crystal Sword Recipe!", 60);
+            }
         }
     }
 }

--- a/src/rpg/systems/ShopSystem.java
+++ b/src/rpg/systems/ShopSystem.java
@@ -1,44 +1,58 @@
 package rpg.systems;
 
-import java.util.Scanner;
+import java.util.*;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
 import rpg.items.Blueprint;
 
 public class ShopSystem {
 
+    // ✅ Shop inventory (easy to expand later)
+    private static final List<Blueprint> inventory = Arrays.asList(
+        new Blueprint("Crystal Sword Blueprint", "Crystal Sword", 10),
+        new Blueprint("Flame Axe Blueprint", "Flame Axe", 15),
+        new Blueprint("Shadow Bow Blueprint", "Shadow Bow", 20)
+    );
+
     public static void openShop(GameState state, Scanner scanner) {
         TextEffect.typeWriter("🛒 Welcome to my shop! What would you like to buy?", 50);
-        TextEffect.typeWriter("1. Crystal Sword Blueprint (10 Shards)", 40);
+
+        // Show inventory
+        for (int i = 0; i < inventory.size(); i++) {
+            Blueprint bp = inventory.get(i);
+            TextEffect.typeWriter((i + 1) + ". " + bp.getName() + " (" + bp.getPrice() + " Shards)", 40);
+        }
         TextEffect.typeWriter("0. Leave shop", 40);
+
         System.out.print("> ");
         String choice = scanner.nextLine();
 
-        switch (choice) {
-            case "1":
-                if (state.shards >= 10) {
-                    state.shards -= 10;
-                    Blueprint bp = new Blueprint("Crystal Sword Blueprint", "Crystal Sword");
+        try {
+            int option = Integer.parseInt(choice);
+            if (option == 0) {
+                TextEffect.typeWriter("You leave the shop.", 40);
+                return;
+            }
 
-                    // ✅ Mark recipe as discoverable, not directly craftable
-                    state.unlockedRecipes.add(bp.getUnlocksRecipe());
+            if (option > 0 && option <= inventory.size()) {
+                Blueprint selected = inventory.get(option - 1);
 
-                    TextEffect.typeWriter(
-                            "You bought the " + bp.getName() +
-                                    "! You can now discover the " + bp.getUnlocksRecipe()
-                                    + " recipe through exploration or drops.",
-                            60);
+                if (state.shards >= selected.getPrice()) {
+                    state.shards -= selected.getPrice();
+
+                    // ✅ Unlock blueprint
+                    state.unlockedRecipes.add(selected.getUnlocksRecipe());
+
+                    TextEffect.typeWriter("You bought the " + selected.getName() +
+                        "! You can now discover the " + selected.getUnlocksRecipe() + " recipe in the world.", 60);
                 } else {
                     TextEffect.typeWriter("You don’t have enough shards.", 60);
                 }
-                break;
-
-            case "0":
-                TextEffect.typeWriter("You leave the shop.", 40);
-                break;
-
-            default:
+            } else {
                 TextEffect.typeWriter("Invalid choice.", 40);
+            }
+        } catch (NumberFormatException e) {
+            TextEffect.typeWriter("Invalid input.", 40);
         }
     }
 }

--- a/src/rpg/systems/ShopSystem.java
+++ b/src/rpg/systems/ShopSystem.java
@@ -1,0 +1,44 @@
+package rpg.systems;
+
+import java.util.Scanner;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+import rpg.items.Blueprint;
+
+public class ShopSystem {
+
+    public static void openShop(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("🛒 Welcome to my shop! What would you like to buy?", 50);
+        TextEffect.typeWriter("1. Crystal Sword Blueprint (10 Shards)", 40);
+        TextEffect.typeWriter("0. Leave shop", 40);
+        System.out.print("> ");
+        String choice = scanner.nextLine();
+
+        switch (choice) {
+            case "1":
+                if (state.shards >= 10) {
+                    state.shards -= 10;
+                    Blueprint bp = new Blueprint("Crystal Sword Blueprint", "Crystal Sword");
+
+                    // ✅ Mark recipe as discoverable, not directly craftable
+                    state.unlockedRecipes.add(bp.getUnlocksRecipe());
+
+                    TextEffect.typeWriter(
+                            "You bought the " + bp.getName() +
+                                    "! You can now discover the " + bp.getUnlocksRecipe()
+                                    + " recipe through exploration or drops.",
+                            60);
+                } else {
+                    TextEffect.typeWriter("You don’t have enough shards.", 60);
+                }
+                break;
+
+            case "0":
+                TextEffect.typeWriter("You leave the shop.", 40);
+                break;
+
+            default:
+                TextEffect.typeWriter("Invalid choice.", 40);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 Changes
- **Story**: Intro updated — player now awakens on the **School Rooftop** instead of a ruined classroom.  
- **Safe Zones**: Zone 2 NPC + shop unlock dialogue triggers only once; removed duplicate shop prompt from `SafeZoneSystem`.  
- **GameLoop**: Added global `shop` command in safe zones after Zone 1; unified shop access across all safe zones.  
- **Status**: Simplified output — only shows **Shards** and **Meat** as currencies (Crystals hidden).  
- **Shop**: Improved feedback when buying blueprints (shows shard cost and remaining balance).  
- **TODO / Needs Fixing**: After buying a blueprint, the recipe requirements are **not yet displayed** — this 