### PR TITLE
Safe Zone & Shop Refactor + Status/Story Updates

### DIFF
--- a/src/rpg/Main.java
+++ b/src/rpg/Main.java
@@ -5,12 +5,16 @@ import java.util.Scanner;
 
 public class Main {
     public static void main(String[] args) {
-        // Title Banner
-        System.out.println("===================================");
-        System.out.println("            DR. CAPSTONE           ");
-        System.out.println("===================================");
-        System.out.println("        v1.0  |  by The Formality");
-        System.out.println("===================================");
+        // Title Banner (ASCII Art)
+        System.out.println(" ______   ______            _______  _______  _______  _______  _______  _______  __    _  _______ ");
+        System.out.println("|      | |    _ |          |       ||   _   ||       ||       ||       ||       ||  |  | ||       |");
+        System.out.println("|  _    ||   | ||          |       ||  |_|  ||    _  ||  _____||_     _||   _   ||   |_| ||    ___|");
+        System.out.println("| | |   ||   |_||_         |       ||       ||   |_| || |_____   |   |  |  | |  ||       ||   |___ ");
+        System.out.println("| |_|   ||    __  | ___    |      _||       ||    ___||_____  |  |   |  |  |_|  ||  _    ||    ___|");
+        System.out.println("|       ||   |  | ||   |   |     |_ |   _   ||   |     _____| |  |   |  |       || | |   ||   |___ ");
+        System.out.println("|______| |___|  |_||___|   |_______||__| |__||___|    |_______|  |___|  |_______||_|  |__||_______|");
+        System.out.println("                                     v1.0  |  by The Formality");
+        System.out.println();
 
         // Loading Effect
         System.out.print("Loading");

--- a/src/rpg/game/Game.java
+++ b/src/rpg/game/Game.java
@@ -58,9 +58,15 @@ public class Game {
         }
         TextEffect.typeWriter("...", 120);
 
-        TextEffect.typeWriter("[POV] Crack. You awaken in a ruined classroom.", 60);
+        // ✅ Updated to rooftop instead of classroom
+        TextEffect.typeWriter("[POV] Crack. You awaken on the School Rooftop.", 60);
         TextEffect.typeWriter(
-                "Desks lie broken, vines crawl through shattered windows, your classmates stand petrified.", 60);
+                "The city below is eerily silent. Statues of your classmates stand frozen in time, " +
+                        "while vines creep across the broken walls around you.",
+                60);
+        TextEffect.typeWriter(
+                "The rooftop feels like a fragile sanctuary amidst the chaos — your first Safe Zone.", 60);
+
     }
 
     private void createPlayer() {

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -6,6 +6,7 @@ import rpg.characters.Player;
 import rpg.systems.CraftingSystem;
 import rpg.systems.ExplorationSystem;
 import rpg.systems.StatusSystem;
+import rpg.systems.ShopSystem; // ✅ import shop
 import rpg.utils.TextEffect;
 
 public class GameLoop {
@@ -27,7 +28,12 @@ public class GameLoop {
         while (running) {
             // 🆕 Dynamic prompt
             if (state.inSafeZone) {
-                System.out.print("> (craft / search / status / move): ");
+                // ✅ Add shop option if zone > 1 (after defeating Zone 1 boss)
+                if (state.zone > 1) {
+                    System.out.print("> (craft / search / status / shop / move): ");
+                } else {
+                    System.out.print("> (craft / search / status / move): ");
+                }
             } else {
                 System.out.print("> (search / status / move): ");
             }
@@ -37,7 +43,6 @@ public class GameLoop {
             switch (command.toLowerCase()) {
                 case "craft":
                     if (state.inSafeZone) {
-                        // ✅ Pass GameState as third argument
                         state.crystals = CraftingSystem.craftWeapon(player, state.crystals, state);
                     } else {
                         TextEffect.typeWriter("⚒️ You can only craft while inside a Safe Zone.", 50);
@@ -53,15 +58,21 @@ public class GameLoop {
                     break;
 
                 case "status":
-                    StatusSystem.showStatus(player, state.crystals, state.meat);
+                    StatusSystem.showStatus(player, state.meat, state.shards);
+                    break;
+
+                case "shop":
+                    if (state.inSafeZone && state.zone > 1) {
+                        ShopSystem.openShop(state, scanner);
+                    } else {
+                        TextEffect.typeWriter("The shop is not available yet.", 50);
+                    }
                     break;
 
                 case "move":
                     ExplorationSystem.handleMove(
-                        player, scanner, rand, state,
-                        // ✅ Pass scanner into SafeZoneSystem
-                        () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state, scanner)
-                    );
+                            player, scanner, rand, state,
+                            () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state, scanner));
                     break;
 
                 default:

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -37,7 +37,8 @@ public class GameLoop {
             switch (command.toLowerCase()) {
                 case "craft":
                     if (state.inSafeZone) {
-                        state.crystals = CraftingSystem.craftWeapon(player, state.crystals);
+                        // ✅ Pass GameState as third argument
+                        state.crystals = CraftingSystem.craftWeapon(player, state.crystals, state);
                     } else {
                         TextEffect.typeWriter("⚒️ You can only craft while inside a Safe Zone.", 50);
                     }
@@ -56,8 +57,11 @@ public class GameLoop {
                     break;
 
                 case "move":
-                    ExplorationSystem.handleMove(player, scanner, rand, state,
-                            () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state));
+                    ExplorationSystem.handleMove(
+                        player, scanner, rand, state,
+                        // ✅ Pass scanner into SafeZoneSystem
+                        () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state, scanner)
+                    );
                     break;
 
                 default:

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -29,4 +29,6 @@ public class GameState {
 
     // ✅ Shop unlock flag
     public boolean shopUnlocked = false;
+
+    public boolean zone2IntroShown = false;
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -16,9 +16,10 @@ public class GameState {
     public Enemy currentZoneBoss; 
     public boolean inSafeZone = false;
 
-    // ✅ Track crafted stage weapons
-    public boolean hasStageWeapon1 = false;
-    public boolean hasStageWeapon2 = false;
+    // ✅ Track crafted stage weapons (consistent naming)
+    public boolean stage1WeaponCrafted = false;
+    public boolean stage2WeaponCrafted = false;
+    public boolean stage3WeaponCrafted = false; // future-proofing
 
     // ✅ Track unlocked blueprints
     public Set<String> unlockedRecipes = new HashSet<>();
@@ -26,6 +27,6 @@ public class GameState {
     // ✅ Track obtained recipe items
     public Map<String, Boolean> recipeItems = new HashMap<>();
 
+    // ✅ Shop unlock flag
     public boolean shopUnlocked = false;
-
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -9,4 +9,6 @@ public class GameState {
     public int revivalPotions = 0;
     public Enemy currentZoneBoss; 
     public boolean inSafeZone = false;
+    public boolean hasStageWeapon1 = false;
+    public boolean hasStageWeapon2 = false;
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -1,7 +1,9 @@
 package rpg.game;
 
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Set;
+import java.util.Map;
 import rpg.characters.Enemy;
 
 public class GameState {
@@ -16,12 +18,11 @@ public class GameState {
 
     // ✅ Track crafted stage weapons
     public boolean hasStageWeapon1 = false;
-    public boolean hasStageWeapon2 = false;\
-
+    public boolean hasStageWeapon2 = false;
 
     // ✅ Track unlocked blueprints
     public Set<String> unlockedRecipes = new HashSet<>();
 
-    public boolean hasCrystalSwordRecipeItem = false; // obtained via drop/search
-
+    // ✅ Track obtained recipe items
+    public Map<String, Boolean> recipeItems = new HashMap<>();
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -1,5 +1,9 @@
 package rpg.game;
+
+import java.util.HashSet;
+import java.util.Set;
 import rpg.characters.Enemy;
+
 public class GameState {
     public int zone = 1;
     public int forwardSteps = 0;
@@ -9,6 +13,15 @@ public class GameState {
     public int revivalPotions = 0;
     public Enemy currentZoneBoss; 
     public boolean inSafeZone = false;
+
+    // ✅ Track crafted stage weapons
     public boolean hasStageWeapon1 = false;
-    public boolean hasStageWeapon2 = false;
+    public boolean hasStageWeapon2 = false;\
+
+
+    // ✅ Track unlocked blueprints
+    public Set<String> unlockedRecipes = new HashSet<>();
+
+    public boolean hasCrystalSwordRecipeItem = false; // obtained via drop/search
+
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -25,4 +25,7 @@ public class GameState {
 
     // ✅ Track obtained recipe items
     public Map<String, Boolean> recipeItems = new HashMap<>();
+
+    public boolean shopUnlocked = false;
+
 }

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -69,8 +69,16 @@ public class Tutorial {
                 case "craft":
                     if (hasCrystal && hasPencil && player.getWeapon() == null) {
                         state.crystals -= 1;
-                        player.equipWeapon(new Weapon("Pencil Blade", 10));
+
+                        // ✅ Use the full constructor: name, minDamage, maxDamage, critChance,
+                        // critMultiplier
+                        player.equipWeapon(new Weapon("Pencil Blade", 8, 12, 0.05, 1.5));
+
                         TextEffect.typeWriter("You combined a Pencil and a Crystal into a Pencil Blade!", 60);
+
+                        // Optional: mark stage 1 weapon crafted in GameState
+                        state.stage1WeaponCrafted = true;
+
                     } else {
                         TextEffect.typeWriter("You can’t craft anything new right now.", 60);
                     }

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -27,7 +27,9 @@ public class Tutorial {
     }
 
     public void start() {
-        TextEffect.typeWriter("[Narrator] You feel weak. You need food and a weapon.", 80);
+        TextEffect.typeWriter("🏫 [Narrator] You awaken on the School Rooftop — your first Safe Zone.", 80);
+        TextEffect.typeWriter("The world below is silent, statues of your classmates frozen in time.", 80);
+        TextEffect.typeWriter("You feel weak. You need food and a weapon.", 80);
         TextEffect.typeWriter("Objective: Find food + find a weapon.", 80);
 
         TextEffect.typeWriter("[Narrator] Remember: crafting can only be done while inside a Safe Zone.", 80);
@@ -43,7 +45,7 @@ public class Tutorial {
             switch (command.toLowerCase()) {
                 case "search":
                     if (!hasCrystal && !hasPencil) {
-                        TextEffect.typeWriter("You search the ruined classroom...", 60);
+                        TextEffect.typeWriter("You search the school rooftop...", 60);
                         TextEffect.typeWriter("You found: 1 Crystal, 1 Crystal Shard, and a Pencil.", 60);
 
                         // 🆕 Narrator explains the difference

--- a/src/rpg/items/Blueprint.java
+++ b/src/rpg/items/Blueprint.java
@@ -1,0 +1,19 @@
+package rpg.items;
+
+public class Blueprint {
+    private String name;
+    private String unlocksRecipe;
+
+    public Blueprint(String name, String unlocksRecipe) {
+        this.name = name;
+        this.unlocksRecipe = unlocksRecipe;
+    }
+
+    public String getName() { return name; }
+    public String getUnlocksRecipe() { return unlocksRecipe; }
+
+    @Override
+    public String toString() {
+        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ")";
+    }
+}

--- a/src/rpg/items/Blueprint.java
+++ b/src/rpg/items/Blueprint.java
@@ -3,17 +3,20 @@ package rpg.items;
 public class Blueprint {
     private String name;
     private String unlocksRecipe;
+    private int price;
 
-    public Blueprint(String name, String unlocksRecipe) {
+    public Blueprint(String name, String unlocksRecipe, int price) {
         this.name = name;
         this.unlocksRecipe = unlocksRecipe;
+        this.price = price;
     }
 
     public String getName() { return name; }
     public String getUnlocksRecipe() { return unlocksRecipe; }
+    public int getPrice() { return price; }
 
     @Override
     public String toString() {
-        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ")";
+        return "Blueprint: " + name + " (Unlocks: " + unlocksRecipe + ", Price: " + price + " Shards)";
     }
 }

--- a/src/rpg/items/Weapon.java
+++ b/src/rpg/items/Weapon.java
@@ -1,19 +1,41 @@
 package rpg.items;
 
+import java.util.Random;
+
 public class Weapon {
     private String name;
-    private int damage;
+    private int minDamage;
+    private int maxDamage;
+    private double critChance;   // e.g. 0.1 = 10% chance
+    private double critMultiplier; // e.g. 2.0 = double damage
 
-    public Weapon(String name, int damage) {
+    public Weapon(String name, int minDamage, int maxDamage, double critChance, double critMultiplier) {
         this.name = name;
-        this.damage = damage;
+        this.minDamage = minDamage;
+        this.maxDamage = maxDamage;
+        this.critChance = critChance;
+        this.critMultiplier = critMultiplier;
     }
 
     public String getName() { return name; }
-    public int getDamage() { return damage; }
+    public int getMinDamage() { return minDamage; }
+    public int getMaxDamage() { return maxDamage; }
+    public double getCritChance() { return critChance; }
+    public double getCritMultiplier() { return critMultiplier; }
+
+    // 🎲 Roll damage dynamically
+    public int rollDamage(Random rand) {
+        int dmg = rand.nextInt(maxDamage - minDamage + 1) + minDamage;
+        if (rand.nextDouble() < critChance) {
+            System.out.println("💥 Critical Hit!");
+            dmg = (int)(dmg * critMultiplier);
+        }
+        return dmg;
+    }
 
     @Override
     public String toString() {
-        return name + " (Damage: " + damage + ")";
+        return name + " (Damage: " + minDamage + "-" + maxDamage + 
+               ", Crit: " + (int)(critChance * 100) + "% x" + critMultiplier + ")";
     }
 }

--- a/src/rpg/systems/BossGateSystem.java
+++ b/src/rpg/systems/BossGateSystem.java
@@ -1,0 +1,29 @@
+package rpg.systems;
+
+import rpg.characters.Player;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+
+public class BossGateSystem {
+
+    public static boolean canFightBoss(GameState state, Player player, Runnable safeZoneAction) {
+        // Stage 1 requirement
+        if (state.zone == 1 && !state.stage1WeaponCrafted) {
+            TextEffect.typeWriter("You sense overwhelming danger ahead. You must forge the Crystal Dagger before facing this boss.", 70);
+            state.inSafeZone = true;
+            safeZoneAction.run();
+            return false;
+        }
+
+        // Stage 2 requirement
+        if (state.zone == 2 && !state.stage2WeaponCrafted) {
+            TextEffect.typeWriter("The path is blocked by a powerful aura. Only the Crystal Sword can pierce it.", 70);
+            state.inSafeZone = true;
+            safeZoneAction.run();
+            return false;
+        }
+
+        // ✅ Add more stages as needed
+        return true;
+    }
+}

--- a/src/rpg/systems/BossGateSystem.java
+++ b/src/rpg/systems/BossGateSystem.java
@@ -7,15 +7,7 @@ import rpg.game.GameState;
 public class BossGateSystem {
 
     public static boolean canFightBoss(GameState state, Player player, Runnable safeZoneAction) {
-        // Stage 1 requirement
-        if (state.zone == 1 && !state.stage1WeaponCrafted) {
-            TextEffect.typeWriter("You sense overwhelming danger ahead. You must forge the Crystal Dagger before facing this boss.", 70);
-            state.inSafeZone = true;
-            safeZoneAction.run();
-            return false;
-        }
-
-        // Stage 2 requirement
+        // Stage 2 requirement (Crystal Sword)
         if (state.zone == 2 && !state.stage2WeaponCrafted) {
             TextEffect.typeWriter("The path is blocked by a powerful aura. Only the Crystal Sword can pierce it.", 70);
             state.inSafeZone = true;

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -3,24 +3,19 @@ package rpg.systems;
 import rpg.characters.Player;
 import rpg.items.Weapon;
 import rpg.utils.TextEffect;
+import rpg.game.GameState;
 
 public class CraftingSystem {
-public static int craftWeapon(Player player, int crystals, GameState state) {
-    if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
-        crystals -= 3;
-        player.equipWeapon(new Weapon("Crystal Dagger", 20));
-        state.stage1WeaponCrafted = true; // ✅ mark stage 1 weapon crafted
-        TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
-    } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
-        crystals -= 5;
-        player.equipWeapon(new Weapon("Crystal Sword", 35));
-        state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
-        TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
-    } else {
-        TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+    public static int craftWeapon(Player player, int crystals, GameState state) {
+        // Upgrade Pencil Blade → Crystal Sword
+        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 5) {
+            crystals -= 5;
+            player.equipWeapon(new Weapon("Crystal Sword", 35));
+            state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+            TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+        } else {
+            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+        }
+        return crystals;
     }
-    return crystals;
 }
-
-}
-

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -5,19 +5,22 @@ import rpg.items.Weapon;
 import rpg.utils.TextEffect;
 
 public class CraftingSystem {
-    public static int craftWeapon(Player player, int crystals) {
-        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
-            crystals -= 3;
-            player.equipWeapon(new Weapon("Crystal Dagger", 20));
-            TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
-        } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
-            crystals -= 5;
-            player.equipWeapon(new Weapon("Crystal Sword", 35));
-            TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
-        } else {
-            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
-        }
-        return crystals;
+public static int craftWeapon(Player player, int crystals, GameState state) {
+    if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 3) {
+        crystals -= 3;
+        player.equipWeapon(new Weapon("Crystal Dagger", 20));
+        state.stage1WeaponCrafted = true; // ✅ mark stage 1 weapon crafted
+        TextEffect.typeWriter("You forged a Crystal Dagger! Stronger than your Pencil Blade.", 60);
+    } else if (player.getWeapon() != null && player.getWeapon().getName().equals("Crystal Dagger") && crystals >= 5) {
+        crystals -= 5;
+        player.equipWeapon(new Weapon("Crystal Sword", 35));
+        state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+        TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+    } else {
+        TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
     }
+    return crystals;
+}
+
 }
 

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -7,24 +7,25 @@ import rpg.game.GameState;
 
 public class CraftingSystem {
     public static int craftWeapon(Player player, int crystals, GameState state) {
-        // Upgrade Pencil Blade → Crystal Sword (requires blueprint)
-        if (player.getWeapon() != null
-                && player.getWeapon().getName().equals("Pencil Blade")
-                && crystals >= 5
-                && state.unlockedRecipes.contains("Crystal Sword")
-                && state.hasCrystalSwordRecipeItem) {
+        // Example: Pencil Blade → Crystal Sword
+        String target = "Crystal Sword";
+
+        if (player.getWeapon() != null 
+            && player.getWeapon().getName().equals("Pencil Blade") 
+            && crystals >= 5 
+            && state.unlockedRecipes.contains(target) 
+            && state.recipeItems.getOrDefault(target, false)) {
 
             crystals -= 5;
-            player.equipWeapon(new Weapon("Crystal Sword", 35));
+            player.equipWeapon(new Weapon("Crystal Sword", 20, 35, 0.10, 2.0));
             state.hasStageWeapon2 = true;
             TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
 
-        } else if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+        } else if (state.unlockedRecipes.contains(target) && !state.recipeItems.getOrDefault(target, false)) {
             TextEffect.typeWriter("You know the blueprint, but you haven’t found the recipe item yet.", 60);
         } else {
             TextEffect.typeWriter("You don’t have the requirements to craft this weapon.", 60);
         }
-
         return crystals;
     }
 }

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -7,15 +7,24 @@ import rpg.game.GameState;
 
 public class CraftingSystem {
     public static int craftWeapon(Player player, int crystals, GameState state) {
-        // Upgrade Pencil Blade → Crystal Sword
-        if (player.getWeapon() != null && player.getWeapon().getName().equals("Pencil Blade") && crystals >= 5) {
+        // Upgrade Pencil Blade → Crystal Sword (requires blueprint)
+        if (player.getWeapon() != null
+                && player.getWeapon().getName().equals("Pencil Blade")
+                && crystals >= 5
+                && state.unlockedRecipes.contains("Crystal Sword")
+                && state.hasCrystalSwordRecipeItem) {
+
             crystals -= 5;
             player.equipWeapon(new Weapon("Crystal Sword", 35));
-            state.stage2WeaponCrafted = true; // ✅ mark stage 2 weapon crafted
+            state.hasStageWeapon2 = true;
             TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
+
+        } else if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            TextEffect.typeWriter("You know the blueprint, but you haven’t found the recipe item yet.", 60);
         } else {
-            TextEffect.typeWriter("You don’t have enough crystals or the right base weapon.", 60);
+            TextEffect.typeWriter("You don’t have the requirements to craft this weapon.", 60);
         }
+
         return crystals;
     }
 }

--- a/src/rpg/systems/CraftingSystem.java
+++ b/src/rpg/systems/CraftingSystem.java
@@ -18,7 +18,7 @@ public class CraftingSystem {
 
             crystals -= 5;
             player.equipWeapon(new Weapon("Crystal Sword", 20, 35, 0.10, 2.0));
-            state.hasStageWeapon2 = true;
+            state.stage2WeaponCrafted = true;
             TextEffect.typeWriter("You forged a Crystal Sword! Its edge gleams with power.", 60);
 
         } else if (state.unlockedRecipes.contains(target) && !state.recipeItems.getOrDefault(target, false)) {

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -36,6 +36,12 @@ public class ExplorationSystem {
             state.forwardSteps++;
 
             if (state.forwardSteps >= 5) {
+                // 🛡️ Check if player can fight boss (weapon requirement)
+                if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
+                    return; // stop here if requirement not met
+                }
+
+                // ✅ If requirement met, proceed to boss fight
                 CombatSystem combat = new CombatSystem(state);
                 boolean win = combat.startCombat(player, zone.boss);
                 if (win) {
@@ -50,6 +56,7 @@ public class ExplorationSystem {
                     safeZoneAction.run();
                 }
             } else {
+                // Random mob encounter
                 Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
                 CombatSystem combat = new CombatSystem(state);
                 if (combat.startCombat(player, mob)) {

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -61,7 +61,7 @@ public class ExplorationSystem {
                 CombatSystem combat = new CombatSystem(state);
                 if (combat.startCombat(player, mob)) {
                     // 🆕 delegate loot handling
-                    LootSystem.dropLoot(state, rand);
+                    LootSystem.dropLoot(state); // ✅ fixed: only pass GameState
                 }
             }
         } else {

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -8,9 +8,9 @@ public class LootSystem {
     private static Random rand = new Random();
 
     public static void dropLoot(GameState state) {
-        int crystalDrop = (rand.nextInt(100) < 10) ? 1 : 0; // 10% chance
-        int meatDrop = rand.nextInt(2);                     // 0–1
-        int shardDrop = 1 + rand.nextInt(3);                // 1–3
+        int crystalDrop = (rand.nextInt(100) < 10) ? 1 : 0;
+        int meatDrop = rand.nextInt(2);
+        int shardDrop = 1 + rand.nextInt(3);
 
         state.crystals += crystalDrop;
         state.meat += meatDrop;
@@ -21,11 +21,13 @@ public class LootSystem {
         if (crystalDrop > 0) lootMsg.append(", +" + crystalDrop + " Crystal");
         if (meatDrop > 0) lootMsg.append(", +" + meatDrop + " Meat");
 
-        // ✅ Check for recipe item drop (only if blueprint unlocked)
-        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
-            if (rand.nextInt(100) < 15) { // 15% chance from loot
-                state.hasCrystalSwordRecipeItem = true;
-                lootMsg.append(", ✨ Crystal Sword Recipe");
+        // ✅ Check for recipe item drop
+        for (String recipe : state.unlockedRecipes) {
+            if (!state.recipeItems.getOrDefault(recipe, false)) {
+                if (rand.nextInt(100) < 15) { // 15% chance
+                    state.recipeItems.put(recipe, true);
+                    lootMsg.append(", ✨ " + recipe + " Recipe");
+                }
             }
         }
 

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -21,6 +21,14 @@ public class LootSystem {
         if (crystalDrop > 0) lootMsg.append(", +" + crystalDrop + " Crystal");
         if (meatDrop > 0) lootMsg.append(", +" + meatDrop + " Meat");
 
+        // ✅ Check for recipe item drop (only if blueprint unlocked)
+        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            if (rand.nextInt(100) < 15) { // 15% chance from loot
+                state.hasCrystalSwordRecipeItem = true;
+                lootMsg.append(", ✨ Crystal Sword Recipe");
+            }
+        }
+
         TextEffect.typeWriter(lootMsg.toString(), 50);
     }
 }

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -27,7 +27,7 @@ public class SafeZoneSystem {
         }
     }
 
-    private static void zone1Interaction(GameState state, Scanner scanner) {
+    private static void zone1Interaction() {
         TextEffect.typeWriter("You rest on the School Rooftop. Your stats are restored.", 60);
     }
 

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -32,37 +32,36 @@ public class SafeZoneSystem {
     }
 
     private static void zone2Interaction(GameState state, Scanner scanner) {
-        // Step 1: Story NPC
-        TextEffect.typeWriter("[Elder Scholar] Traveler, the guardian ahead cannot be harmed by ordinary steel.", 60);
-        TextEffect.typeWriter("Seek the knowledge of forging — only then will you stand a chance.", 60);
+        if (!state.zone2IntroShown) {
+            // Step 1: Story NPC
+            TextEffect.typeWriter("[Elder Scholar] Traveler, the guardian ahead cannot be harmed by ordinary steel.",
+                    60);
+            TextEffect.typeWriter("Seek the knowledge of forging — only then will you stand a chance.", 60);
 
-        // Step 2: Shop NPC introduction
-        TextEffect.typeWriter("\nA merchant approaches you.", 60);
-        TextEffect.typeWriter("[Merchant] Greetings! I deal in blueprints and secrets of crafting.", 60);
-        TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
+            // Step 2: Shop NPC introduction
+            TextEffect.typeWriter("\nA merchant approaches you.", 60);
+            TextEffect.typeWriter("[Merchant] Greetings! I deal in blueprints and secrets of crafting.", 60);
+            TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
 
-        // ✅ Unlock shop globally
-        state.shopUnlocked = true;
+            // ✅ Unlock shop globally
+            state.shopUnlocked = true;
+            state.zone2IntroShown = true; // mark as shown
 
-        // Offer immediate shop access
-        System.out.print("Do you want to browse the shop now? (yes/no): ");
-        String choice = scanner.nextLine();
-        if (choice.equalsIgnoreCase("yes")) {
-            ShopSystem.openShop(state, scanner);
+            // Offer immediate shop access
+            System.out.print("Do you want to browse the shop now? (yes/no): ");
+            String choice = scanner.nextLine();
+            if (choice.equalsIgnoreCase("yes")) {
+                ShopSystem.openShop(state, scanner);
+            }
+        } else {
+            // After intro has been shown, just generic safe zone with shop access
+            genericInteraction(state, scanner);
         }
     }
 
     private static void genericInteraction(GameState state, Scanner scanner) {
         TextEffect.typeWriter("You rest safely here.", 60);
-
-        // ✅ If shop unlocked, allow access
-        if (state.shopUnlocked) {
-            System.out.print("Do you want to visit the shop? (yes/no): ");
-            String choice = scanner.nextLine();
-            if (choice.equalsIgnoreCase("yes")) {
-                ShopSystem.openShop(state, scanner);
-            }
-        }
+        // Shop option is now handled globally in GameLoop
     }
 
     public static void searchSafeZone(Player player, GameState state) {

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -1,15 +1,68 @@
 package rpg.systems;
 
+import java.util.Scanner;
 import rpg.characters.Player;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
 
 public class SafeZoneSystem {
-    public static void enterSafeZone(Player player, GameState state) {
+
+    public static void enterSafeZone(Player player, GameState state, Scanner scanner) {
+        // ✅ Always heal
         player.healFull();
-        state.inSafeZone = true; // 🆕 mark safe zone
+        state.inSafeZone = true;
         TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
         TextEffect.typeWriter("Your stats have been fully restored.", 60);
+
+        // ✅ Zone-specific interactions
+        switch (state.zone) {
+            case 1:
+                zone1Interaction();
+                break;
+            case 2:
+                zone2Interaction(state, scanner);
+                break;
+            default:
+                genericInteraction(state, scanner);
+        }
+    }
+
+    private static void zone1Interaction() {
+        TextEffect.typeWriter("This place feels calm. You take a moment to breathe.", 60);
+    }
+
+    private static void zone2Interaction(GameState state, Scanner scanner) {
+        // Step 1: Story NPC
+        TextEffect.typeWriter("[Elder Scholar] Traveler, the guardian ahead cannot be harmed by ordinary steel.", 60);
+        TextEffect.typeWriter("Seek the knowledge of forging — only then will you stand a chance.", 60);
+
+        // Step 2: Shop NPC introduction
+        TextEffect.typeWriter("\nA merchant approaches you.", 60);
+        TextEffect.typeWriter("[Merchant] Greetings! I deal in blueprints and secrets of crafting.", 60);
+        TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
+
+        // ✅ Unlock shop globally
+        state.shopUnlocked = true;
+
+        // Offer immediate shop access
+        System.out.print("Do you want to browse the shop now? (yes/no): ");
+        String choice = scanner.nextLine();
+        if (choice.equalsIgnoreCase("yes")) {
+            ShopSystem.openShop(state, scanner);
+        }
+    }
+
+    private static void genericInteraction(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("You rest safely here.", 60);
+
+        // ✅ If shop unlocked, allow access
+        if (state.shopUnlocked) {
+            System.out.print("Do you want to visit the shop? (yes/no): ");
+            String choice = scanner.nextLine();
+            if (choice.equalsIgnoreCase("yes")) {
+                ShopSystem.openShop(state, scanner);
+            }
+        }
     }
 
     public static void searchSafeZone(Player player, GameState state) {

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -27,8 +27,8 @@ public class SafeZoneSystem {
         }
     }
 
-    private static void zone1Interaction() {
-        TextEffect.typeWriter("This place feels calm. You take a moment to breathe.", 60);
+    private static void zone1Interaction(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("You rest on the School Rooftop. Your stats are restored.", 60);
     }
 
     private static void zone2Interaction(GameState state, Scanner scanner) {

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -13,23 +13,22 @@ public class SearchSystem {
         if (roll < 40) {
             state.shards++;
             TextEffect.typeWriter("You scavenge the area and find a Shard!", 50);
-
         } else if (roll < 70) {
             state.meat++;
             TextEffect.typeWriter("You hunt around and find some Meat.", 50);
-
         } else if (roll < 90) {
             TextEffect.typeWriter("You discover a small vial of medicine — it might help later.", 50);
-
         } else {
             TextEffect.typeWriter("You search the area but find nothing of value.", 50);
         }
 
         // ✅ Chance to find recipe item if blueprint unlocked
-        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
-            if (rand.nextInt(100) < 10) { // 10% chance from searching
-                state.hasCrystalSwordRecipeItem = true;
-                TextEffect.typeWriter("✨ While searching, you uncover the Crystal Sword Recipe!", 60);
+        for (String recipe : state.unlockedRecipes) {
+            if (!state.recipeItems.getOrDefault(recipe, false)) {
+                if (rand.nextInt(100) < 10) { // 10% chance
+                    state.recipeItems.put(recipe, true);
+                    TextEffect.typeWriter("✨ While searching, you uncover the " + recipe + " Recipe!", 60);
+                }
             }
         }
     }

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -9,16 +9,28 @@ public class SearchSystem {
 
     public static void search(GameState state) {
         int roll = rand.nextInt(100);
+
         if (roll < 40) {
-            state.crystals++;
+            state.shards++;
             TextEffect.typeWriter("You scavenge the area and find a Shard!", 50);
+
         } else if (roll < 70) {
             state.meat++;
             TextEffect.typeWriter("You hunt around and find some Meat.", 50);
+
         } else if (roll < 90) {
             TextEffect.typeWriter("You discover a small vial of medicine — it might help later.", 50);
+
         } else {
             TextEffect.typeWriter("You search the area but find nothing of value.", 50);
+        }
+
+        // ✅ Chance to find recipe item if blueprint unlocked
+        if (state.unlockedRecipes.contains("Crystal Sword") && !state.hasCrystalSwordRecipeItem) {
+            if (rand.nextInt(100) < 10) { // 10% chance from searching
+                state.hasCrystalSwordRecipeItem = true;
+                TextEffect.typeWriter("✨ While searching, you uncover the Crystal Sword Recipe!", 60);
+            }
         }
     }
 }

--- a/src/rpg/systems/ShopSystem.java
+++ b/src/rpg/systems/ShopSystem.java
@@ -1,44 +1,58 @@
 package rpg.systems;
 
-import java.util.Scanner;
+import java.util.*;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
 import rpg.items.Blueprint;
 
 public class ShopSystem {
 
+    // ✅ Shop inventory (easy to expand later)
+    private static final List<Blueprint> inventory = Arrays.asList(
+        new Blueprint("Crystal Sword Blueprint", "Crystal Sword", 10),
+        new Blueprint("Flame Axe Blueprint", "Flame Axe", 15),
+        new Blueprint("Shadow Bow Blueprint", "Shadow Bow", 20)
+    );
+
     public static void openShop(GameState state, Scanner scanner) {
         TextEffect.typeWriter("🛒 Welcome to my shop! What would you like to buy?", 50);
-        TextEffect.typeWriter("1. Crystal Sword Blueprint (10 Shards)", 40);
+
+        // Show inventory
+        for (int i = 0; i < inventory.size(); i++) {
+            Blueprint bp = inventory.get(i);
+            TextEffect.typeWriter((i + 1) + ". " + bp.getName() + " (" + bp.getPrice() + " Shards)", 40);
+        }
         TextEffect.typeWriter("0. Leave shop", 40);
+
         System.out.print("> ");
         String choice = scanner.nextLine();
 
-        switch (choice) {
-            case "1":
-                if (state.shards >= 10) {
-                    state.shards -= 10;
-                    Blueprint bp = new Blueprint("Crystal Sword Blueprint", "Crystal Sword");
+        try {
+            int option = Integer.parseInt(choice);
+            if (option == 0) {
+                TextEffect.typeWriter("You leave the shop.", 40);
+                return;
+            }
 
-                    // ✅ Mark recipe as discoverable, not directly craftable
-                    state.unlockedRecipes.add(bp.getUnlocksRecipe());
+            if (option > 0 && option <= inventory.size()) {
+                Blueprint selected = inventory.get(option - 1);
 
-                    TextEffect.typeWriter(
-                            "You bought the " + bp.getName() +
-                                    "! You can now discover the " + bp.getUnlocksRecipe()
-                                    + " recipe through exploration or drops.",
-                            60);
+                if (state.shards >= selected.getPrice()) {
+                    state.shards -= selected.getPrice();
+
+                    // ✅ Unlock blueprint
+                    state.unlockedRecipes.add(selected.getUnlocksRecipe());
+
+                    TextEffect.typeWriter("You bought the " + selected.getName() +
+                        "! You can now discover the " + selected.getUnlocksRecipe() + " recipe in the world.", 60);
                 } else {
                     TextEffect.typeWriter("You don’t have enough shards.", 60);
                 }
-                break;
-
-            case "0":
-                TextEffect.typeWriter("You leave the shop.", 40);
-                break;
-
-            default:
+            } else {
                 TextEffect.typeWriter("Invalid choice.", 40);
+            }
+        } catch (NumberFormatException e) {
+            TextEffect.typeWriter("Invalid input.", 40);
         }
     }
 }

--- a/src/rpg/systems/ShopSystem.java
+++ b/src/rpg/systems/ShopSystem.java
@@ -1,0 +1,44 @@
+package rpg.systems;
+
+import java.util.Scanner;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+import rpg.items.Blueprint;
+
+public class ShopSystem {
+
+    public static void openShop(GameState state, Scanner scanner) {
+        TextEffect.typeWriter("🛒 Welcome to my shop! What would you like to buy?", 50);
+        TextEffect.typeWriter("1. Crystal Sword Blueprint (10 Shards)", 40);
+        TextEffect.typeWriter("0. Leave shop", 40);
+        System.out.print("> ");
+        String choice = scanner.nextLine();
+
+        switch (choice) {
+            case "1":
+                if (state.shards >= 10) {
+                    state.shards -= 10;
+                    Blueprint bp = new Blueprint("Crystal Sword Blueprint", "Crystal Sword");
+
+                    // ✅ Mark recipe as discoverable, not directly craftable
+                    state.unlockedRecipes.add(bp.getUnlocksRecipe());
+
+                    TextEffect.typeWriter(
+                            "You bought the " + bp.getName() +
+                                    "! You can now discover the " + bp.getUnlocksRecipe()
+                                    + " recipe through exploration or drops.",
+                            60);
+                } else {
+                    TextEffect.typeWriter("You don’t have enough shards.", 60);
+                }
+                break;
+
+            case "0":
+                TextEffect.typeWriter("You leave the shop.", 40);
+                break;
+
+            default:
+                TextEffect.typeWriter("Invalid choice.", 40);
+        }
+    }
+}

--- a/src/rpg/systems/StatusSystem.java
+++ b/src/rpg/systems/StatusSystem.java
@@ -4,18 +4,18 @@ import rpg.characters.Player;
 import rpg.utils.TextEffect;
 
 public class StatusSystem {
-    public static void showStatus(Player player, int crystals, int meat) {
+    public static void showStatus(Player player, int meat, int shards) {
         TextEffect.typeWriter(
             "\n------ " + player.getName() + ": The " + player.getTrait() + " ------" +
             "\n| HP: " + player.getHp() + "/" + player.getMaxHp() +
-            " | Level: " + player.getLevel() + // ---> new
-            " | EXP: " + player.getExp() + "/" + player.getExpToNextLevel() + // ---> new
+            " | Level: " + player.getLevel() +
+            " | EXP: " + player.getExp() + "/" + player.getExpToNextLevel() +
             " | Mana: " + player.getMana() + "/" + player.getMaxMana() +
             " | Defense: " + player.getDefense() +
             " | Intelligence: " + player.getIntelligence() +
             " | Weapon: " + (player.getWeapon() == null ? "None" : player.getWeapon().toString()) +
-            " | Crystals: " + crystals +
-            " | Meat: " + meat,
+            " | Shards: " + shards +          // ✅ only show shards
+            " | Meat: " + meat,               // ✅ keep meat
             40
         );
     }

--- a/src/rpg/systems/TutorialCombatSystem.java
+++ b/src/rpg/systems/TutorialCombatSystem.java
@@ -1,22 +1,25 @@
 package rpg.systems;
 
 import java.util.Scanner;
+import java.util.Random;
 import rpg.utils.TextEffect;
 import rpg.characters.Player;
 import rpg.characters.Enemy;
 import rpg.items.Consumable;
 import rpg.game.GameState;
+import rpg.items.Weapon;
 
 public class TutorialCombatSystem {
     private Scanner scanner = new Scanner(System.in);
     private GameState state;
+    private Random rand = new Random();
 
     public TutorialCombatSystem(GameState state) {
         this.state = state;
     }
 
     public boolean startTutorialCombat(Player player, Enemy enemy) {
-        TextEffect.typeWriter("⚔️ Tutorial Combat! " + enemy.getName() + " blocks your path!", 50);
+        TextEffect.typeWriter("⚔️ Combat! " + enemy.getName() + " blocks your path!", 50);
 
         while (player.isAlive() && enemy.isAlive()) {
             TextEffect.typeWriter("\nYour HP: " + player.getHp() + "/" + player.getMaxHp() +
@@ -31,10 +34,19 @@ public class TutorialCombatSystem {
 
             switch (action.toLowerCase()) {
                 case "attack":
-                    int dmg = player.getWeapon().getDamage() + (player.getIntelligence() / 2);
-                    enemy.takeDamage(dmg);
-                    TextEffect.typeWriter("You strike with your " + player.getWeapon().getName() +
-                                          " for " + dmg + " damage!", 40);
+                    Weapon weapon = player.getWeapon();
+                    if (weapon != null) {
+                        // ✅ Use rollDamage instead of getDamage
+                        int dmg = weapon.rollDamage(rand) + (player.getIntelligence() / 2);
+                        enemy.takeDamage(dmg);
+                        TextEffect.typeWriter("You strike with your " + weapon.getName() +
+                                              " for " + dmg + " damage!", 40);
+                    } else {
+                        // fallback if no weapon equipped
+                        int dmg = 1 + rand.nextInt(2);
+                        enemy.takeDamage(dmg);
+                        TextEffect.typeWriter("You punch wildly for " + dmg + " damage!", 40);
+                    }
                     break;
 
                 case "defend":

--- a/src/rpg/world/WorldData.java
+++ b/src/rpg/world/WorldData.java
@@ -8,13 +8,16 @@ public class WorldData {
         switch (zone) {
             case 1:
                 return new ZoneConfig(
-                    "Ruined Classroom",
+                    "School Rooftop", // ✅ updated name
                     new Enemy[]{
-                        new Enemy("Wild Beast", 40, 8, 12, 15),
-                        new Enemy("Corrupted Guardian", 60, 12, 18, 20)
+                        new Enemy("Wolf", 40, 8, 12, 15),
+                        new Enemy("Boar", 50, 10, 14, 18),
+                        new Enemy("Crystal Creature", 60, 12, 16, 20)
                     },
-                    new Enemy("Stone Titan", 120, 15, 25, 40),
-                    new Weapon("Pencil Blade", 10)
+                    // Mini‑boss for Zone 1
+                    new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40),
+                    // Starter weapon reward
+                    new Weapon("Pencil Blade", 8, 12, 0.05, 1.5)
                 );
             case 2:
                 return new ZoneConfig(
@@ -24,7 +27,7 @@ public class WorldData {
                         new Enemy("Ent Guardian", 80, 14, 20, 30)
                     },
                     new Enemy("Forest Guardian", 180, 20, 30, 60),
-                    new Weapon("Rusty Sword", 15)
+                    new Weapon("Rusty Sword", 12, 18, 0.08, 1.5)
                 );
             default:
                 return new ZoneConfig(


### PR DESCRIPTION


## 📝 Changes
- **Story**: Intro updated — player now awakens on the **School Rooftop** instead of a ruined classroom.  
- **Safe Zones**: Zone 2 NPC + shop unlock dialogue triggers only once; removed duplicate shop prompt from `SafeZoneSystem`.  
- **GameLoop**: Added global `shop` command in safe zones after Zone 1; unified shop access across all safe zones.  
- **Status**: Simplified output — only shows **Shards** and **Meat** as currencies (Crystals hidden).  
- **Shop**: Improved feedback when buying blueprints (shows shard cost and remaining balance).  
- **TODO / Needs Fixing**: After buying a blueprint, the recipe requirements are **not yet displayed** — this 