### PR TITLE
Safe Zone Refactor, Rooftop Narrative, Combat & Loot Overhaul, GameState Expansion

### DIFF
--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -32,4 +32,7 @@ public class GameState {
 
     public boolean zone2IntroShown = false;
     public boolean skillsUnlocked = false;
+
+    public boolean lootDisplayed = false;   // ✅ already added, prevents duplicate loot text
+
 }

--- a/src/rpg/safezones/RooftopSafeZone.java
+++ b/src/rpg/safezones/RooftopSafeZone.java
@@ -1,0 +1,15 @@
+package rpg.safezones;
+
+import java.util.Scanner;
+import rpg.characters.Player;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+
+public class RooftopSafeZone implements SafeZone {
+    @Override
+    public void enter(Player player, GameState state, Scanner scanner) {
+        player.healFull();
+        state.inSafeZone = true;
+        TextEffect.typeWriter("You rest on the School Rooftop. The wind is calm, and your stats are restored.", 60);
+    }
+}

--- a/src/rpg/safezones/RuinedLabSafeZone.java
+++ b/src/rpg/safezones/RuinedLabSafeZone.java
@@ -1,0 +1,35 @@
+package rpg.safezones;
+
+import java.util.Scanner;
+import rpg.characters.Player;
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+import rpg.systems.ShopSystem;
+
+public class RuinedLabSafeZone implements SafeZone {
+    @Override
+    public void enter(Player player, GameState state, Scanner scanner) {
+        player.healFull();
+        state.inSafeZone = true;
+        TextEffect.typeWriter("You step cautiously into the Ruined Lab. The air smells of rust and chemicals.", 60);
+        TextEffect.typeWriter("Your stats have been fully restored.", 60);
+
+        if (!state.zone2IntroShown) {
+            TextEffect.typeWriter("[Professor Ashiro] These halls once birthed discovery… now they breed only danger.", 60);
+            TextEffect.typeWriter("The guardian ahead is no mere beast — only forged weapons can pierce its hide.", 60);
+
+            TextEffect.typeWriter("\nA scavenger emerges from the shadows of broken machinery.", 60);
+            TextEffect.typeWriter("[Scrapwright Kuro] Heh, I deal in blueprints and scraps of the old world.", 60);
+            TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
+
+            state.shopUnlocked = true;
+            state.zone2IntroShown = true;
+
+            System.out.print("Do you want to browse the shop now? (yes/no): ");
+            String choice = scanner.nextLine();
+            if (choice.equalsIgnoreCase("yes")) {
+                ShopSystem.openShop(state, scanner);
+            }
+        }
+    }
+}

--- a/src/rpg/safezones/SafeZone.java
+++ b/src/rpg/safezones/SafeZone.java
@@ -1,0 +1,9 @@
+package rpg.safezones;
+
+import java.util.Scanner;
+import rpg.characters.Player;
+import rpg.game.GameState;
+
+public interface SafeZone {
+    void enter(Player player, GameState state, Scanner scanner);
+}

--- a/src/rpg/safezones/SafeZoneFactory.java
+++ b/src/rpg/safezones/SafeZoneFactory.java
@@ -1,0 +1,20 @@
+package rpg.safezones;
+
+import java.util.Scanner;
+import rpg.characters.Player;
+import rpg.game.GameState;
+
+public class SafeZoneFactory {
+    public static SafeZone getZone(int zone) {
+        switch (zone) {
+            case 1: return new RooftopSafeZone();
+            case 2: return new RuinedLabSafeZone();
+            // future zones: case 3 -> new CitySafeZone();
+            default: return (player, state, scanner) -> {
+                player.healFull();
+                state.inSafeZone = true;
+                System.out.println("You rest safely here. Your stats are restored.");
+            };
+        }
+    }
+}

--- a/src/rpg/systems/CombatSystem.java
+++ b/src/rpg/systems/CombatSystem.java
@@ -149,8 +149,8 @@ public class CombatSystem {
                 state.revivalPotions++;
                 TextEffect.typeWriter("✨ As the boss falls, you discover a glowing Revival Potion!", 50);
             }
-
-            TextEffect.typeWriter("You loot: Food, Crystals, Shards, Materials.", 50);
+            
+            LootSystem.dropLoot(state);
 
             int expGained = enemy.getExpReward();
             player.gainExp(expGained);

--- a/src/rpg/systems/CombatSystem.java
+++ b/src/rpg/systems/CombatSystem.java
@@ -20,6 +20,7 @@ public class CombatSystem {
     }
 
     public boolean startCombat(Player player, Enemy enemy) {
+        state.lootDisplayed = false;
         TextEffect.typeWriter("⚔️ Combat Start! " + enemy.getName() + " appears!", 50);
 
         try {
@@ -149,7 +150,7 @@ public class CombatSystem {
                 state.revivalPotions++;
                 TextEffect.typeWriter("✨ As the boss falls, you discover a glowing Revival Potion!", 50);
             }
-            
+
             LootSystem.dropLoot(state);
 
             int expGained = enemy.getExpReward();

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -16,21 +16,29 @@ public class LootSystem {
         state.meat += meatDrop;
         state.shards += shardDrop;
 
-        StringBuilder lootMsg = new StringBuilder("Loot: ");
-        lootMsg.append("+" + shardDrop + " Shards");
-        if (crystalDrop > 0) lootMsg.append(", +" + crystalDrop + " Crystal");
-        if (meatDrop > 0) lootMsg.append(", +" + meatDrop + " Meat");
+        TextEffect.typeWriter("📦 Loot acquired:", 50);
+
+        // Always show shards
+        TextEffect.typeWriter("  + " + shardDrop + " Shards", 50);
+
+        // Show crystals only if dropped
+        if (crystalDrop > 0) {
+            TextEffect.typeWriter("  + " + crystalDrop + " Crystal", 50);
+        }
+
+        // Show meat only if dropped
+        if (meatDrop > 0) {
+            TextEffect.typeWriter("  + " + meatDrop + " Meat", 50);
+        }
 
         // ✅ Check for recipe item drop
         for (String recipe : state.unlockedRecipes) {
             if (!state.recipeItems.getOrDefault(recipe, false)) {
                 if (rand.nextInt(100) < 15) { // 15% chance
                     state.recipeItems.put(recipe, true);
-                    lootMsg.append(", ✨ " + recipe + " Recipe");
+                    TextEffect.typeWriter("  ✨ " + recipe + " Recipe", 50);
                 }
             }
         }
-
-        TextEffect.typeWriter(lootMsg.toString(), 50);
     }
 }

--- a/src/rpg/systems/LootSystem.java
+++ b/src/rpg/systems/LootSystem.java
@@ -8,6 +8,11 @@ public class LootSystem {
     private static Random rand = new Random();
 
     public static void dropLoot(GameState state) {
+        if (state.lootDisplayed) {
+            return; // ✅ already shown, skip
+        }
+        state.lootDisplayed = true;
+
         int crystalDrop = (rand.nextInt(100) < 10) ? 1 : 0;
         int meatDrop = rand.nextInt(2);
         int shardDrop = 1 + rand.nextInt(3);
@@ -16,29 +21,24 @@ public class LootSystem {
         state.meat += meatDrop;
         state.shards += shardDrop;
 
-        TextEffect.typeWriter("📦 Loot acquired:", 50);
-
-        // Always show shards
+        TextEffect.typeWriter("\n📦 Loot acquired:", 50);
         TextEffect.typeWriter("  + " + shardDrop + " Shards", 50);
 
-        // Show crystals only if dropped
         if (crystalDrop > 0) {
             TextEffect.typeWriter("  + " + crystalDrop + " Crystal", 50);
         }
-
-        // Show meat only if dropped
         if (meatDrop > 0) {
             TextEffect.typeWriter("  + " + meatDrop + " Meat", 50);
         }
 
-        // ✅ Check for recipe item drop
         for (String recipe : state.unlockedRecipes) {
             if (!state.recipeItems.getOrDefault(recipe, false)) {
-                if (rand.nextInt(100) < 15) { // 15% chance
+                if (rand.nextInt(100) < 15) {
                     state.recipeItems.put(recipe, true);
                     TextEffect.typeWriter("  ✨ " + recipe + " Recipe", 50);
                 }
             }
         }
     }
+
 }

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -12,7 +12,16 @@ public class SafeZoneSystem {
             // ✅ Always heal
             player.healFull();
             state.inSafeZone = true;
-            TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
+
+            // Zone-specific entrance text
+            if (state.zone == 1) {
+                TextEffect.typeWriter("You feel renewed as you enter the School Rooftop.", 60);
+            } else if (state.zone == 2) {
+                TextEffect.typeWriter("You step cautiously into the Ruined Lab. The air smells of rust and chemicals.", 60);
+            } else {
+                TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
+            }
+
             TextEffect.typeWriter("Your stats have been fully restored.", 60);
 
             // ✅ Zone-specific interactions
@@ -36,7 +45,7 @@ public class SafeZoneSystem {
 
     private static void zone1Interaction() {
         try {
-            TextEffect.typeWriter("You rest on the School Rooftop. Your stats are restored.", 60);
+            TextEffect.typeWriter("You rest on the School Rooftop. The wind is calm, and your stats are restored.", 60);
         } catch (Exception e) {
             TextEffect.typeWriter("Something feels off while resting here.", 40);
             System.err.println("Zone1 interaction error -> " + e.getMessage());
@@ -46,13 +55,13 @@ public class SafeZoneSystem {
     private static void zone2Interaction(GameState state, Scanner scanner) {
         try {
             if (!state.zone2IntroShown) {
-                // Step 1: Story NPC
-                TextEffect.typeWriter("[Elder Scholar] Traveler, the guardian ahead cannot be harmed by ordinary steel.", 60);
-                TextEffect.typeWriter("Seek the knowledge of forging — only then will you stand a chance.", 60);
+                // Step 1: Story NPC (Professor Ashiro)
+                TextEffect.typeWriter("[Professor Ashiro] These halls once birthed discovery… now they breed only danger.", 60);
+                TextEffect.typeWriter("The guardian ahead is no mere beast — it is science gone astray. Only forged weapons can pierce its hide.", 60);
 
-                // Step 2: Shop NPC introduction
-                TextEffect.typeWriter("\nA merchant approaches you.", 60);
-                TextEffect.typeWriter("[Merchant] Greetings! I deal in blueprints and secrets of crafting.", 60);
+                // Step 2: Shop NPC introduction (Scrapwright Kuro)
+                TextEffect.typeWriter("\nA scavenger emerges from the shadows of broken machinery.", 60);
+                TextEffect.typeWriter("[Scrapwright Kuro] Heh, I deal in blueprints and scraps of the old world.", 60);
                 TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
 
                 // ✅ Unlock shop globally
@@ -67,7 +76,7 @@ public class SafeZoneSystem {
                         ShopSystem.openShop(state, scanner);
                     }
                 } catch (Exception e) {
-                    TextEffect.typeWriter("You hesitate... the merchant walks away for now.", 40);
+                    TextEffect.typeWriter("You hesitate... the scavenger shrugs and turns away for now.", 40);
                     System.err.println("Shop prompt error -> " + e.getMessage());
                 }
             } else {
@@ -75,14 +84,14 @@ public class SafeZoneSystem {
                 genericInteraction(state, scanner);
             }
         } catch (Exception e) {
-            TextEffect.typeWriter("Something went wrong during the Zone 2 interaction.", 40);
+            TextEffect.typeWriter("Something went wrong during the Ruined Lab interaction.", 40);
             System.err.println("Zone2 interaction error -> " + e.getMessage());
         }
     }
 
     private static void genericInteraction(GameState state, Scanner scanner) {
         try {
-            TextEffect.typeWriter("You rest safely here.", 60);
+            TextEffect.typeWriter("You rest safely here, the chaos outside feels distant for a moment.", 60);
             // Shop option is now handled globally in GameLoop
         } catch (Exception e) {
             TextEffect.typeWriter("You try to rest, but something feels wrong.", 40);
@@ -92,7 +101,7 @@ public class SafeZoneSystem {
 
     public static void searchSafeZone(Player player, GameState state) {
         try {
-            TextEffect.typeWriter("You search around but find nothing useful.", 60);
+            TextEffect.typeWriter("You search around but find nothing useful among the debris.", 60);
         } catch (Exception e) {
             TextEffect.typeWriter("You stumble while searching the safe zone.", 40);
             System.err.println("Safe zone search error -> " + e.getMessage());

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -2,108 +2,22 @@ package rpg.systems;
 
 import java.util.Scanner;
 import rpg.characters.Player;
-import rpg.utils.TextEffect;
 import rpg.game.GameState;
+import rpg.safezones.SafeZone;
+import rpg.safezones.SafeZoneFactory;
+import rpg.utils.TextEffect;
 
 public class SafeZoneSystem {
-
     public static void enterSafeZone(Player player, GameState state, Scanner scanner) {
-        try {
-            // ✅ Always heal
-            player.healFull();
-            state.inSafeZone = true;
-
-            // Zone-specific entrance text
-            if (state.zone == 1) {
-                TextEffect.typeWriter("You feel renewed as you enter the School Rooftop.", 60);
-            } else if (state.zone == 2) {
-                TextEffect.typeWriter("You step cautiously into the Ruined Lab. The air smells of rust and chemicals.", 60);
-            } else {
-                TextEffect.typeWriter("You feel renewed as you enter Safe Zone " + state.zone + ".", 60);
-            }
-
-            TextEffect.typeWriter("Your stats have been fully restored.", 60);
-
-            // ✅ Zone-specific interactions
-            switch (state.zone) {
-                case 1:
-                    zone1Interaction();
-                    break;
-                case 2:
-                    zone2Interaction(state, scanner);
-                    break;
-                default:
-                    genericInteraction(state, scanner);
-            }
-        } catch (Exception e) {
-            TextEffect.typeWriter("Something went wrong while entering the safe zone.", 40);
-            System.err.println("SafeZoneSystem error -> " + e.getMessage());
-        } finally {
-            // Always runs after entering safe zone
-        }
-    }
-
-    private static void zone1Interaction() {
-        try {
-            TextEffect.typeWriter("You rest on the School Rooftop. The wind is calm, and your stats are restored.", 60);
-        } catch (Exception e) {
-            TextEffect.typeWriter("Something feels off while resting here.", 40);
-            System.err.println("Zone1 interaction error -> " + e.getMessage());
-        }
-    }
-
-    private static void zone2Interaction(GameState state, Scanner scanner) {
-        try {
-            if (!state.zone2IntroShown) {
-                // Step 1: Story NPC (Professor Ashiro)
-                TextEffect.typeWriter("[Professor Ashiro] These halls once birthed discovery… now they breed only danger.", 60);
-                TextEffect.typeWriter("The guardian ahead is no mere beast — it is science gone astray. Only forged weapons can pierce its hide.", 60);
-
-                // Step 2: Shop NPC introduction (Scrapwright Kuro)
-                TextEffect.typeWriter("\nA scavenger emerges from the shadows of broken machinery.", 60);
-                TextEffect.typeWriter("[Scrapwright Kuro] Heh, I deal in blueprints and scraps of the old world.", 60);
-                TextEffect.typeWriter("From now on, you can visit my shop in any Safe Zone.", 60);
-
-                // ✅ Unlock shop globally
-                state.shopUnlocked = true;
-                state.zone2IntroShown = true; // mark as shown
-
-                // Offer immediate shop access
-                System.out.print("Do you want to browse the shop now? (yes/no): ");
-                try {
-                    String choice = scanner.nextLine();
-                    if (choice.equalsIgnoreCase("yes")) {
-                        ShopSystem.openShop(state, scanner);
-                    }
-                } catch (Exception e) {
-                    TextEffect.typeWriter("You hesitate... the scavenger shrugs and turns away for now.", 40);
-                    System.err.println("Shop prompt error -> " + e.getMessage());
-                }
-            } else {
-                // After intro has been shown, just generic safe zone with shop access
-                genericInteraction(state, scanner);
-            }
-        } catch (Exception e) {
-            TextEffect.typeWriter("Something went wrong during the Ruined Lab interaction.", 40);
-            System.err.println("Zone2 interaction error -> " + e.getMessage());
-        }
-    }
-
-    private static void genericInteraction(GameState state, Scanner scanner) {
-        try {
-            TextEffect.typeWriter("You rest safely here, the chaos outside feels distant for a moment.", 60);
-            // Shop option is now handled globally in GameLoop
-        } catch (Exception e) {
-            TextEffect.typeWriter("You try to rest, but something feels wrong.", 40);
-            System.err.println("Generic interaction error -> " + e.getMessage());
-        }
+        SafeZone zone = SafeZoneFactory.getZone(state.zone);
+        zone.enter(player, state, scanner);
     }
 
     public static void searchSafeZone(Player player, GameState state) {
         try {
-            TextEffect.typeWriter("You search around but find nothing useful among the debris.", 60);
+            TextEffect.typeWriter("You cannot search while in a Safe Zone. Try moving out first.", 60);
         } catch (Exception e) {
-            TextEffect.typeWriter("You stumble while searching the safe zone.", 40);
+            TextEffect.typeWriter("You stumble while trying to search here.", 40);
             System.err.println("Safe zone search error -> " + e.getMessage());
         }
     }

--- a/src/rpg/world/WorldData.java
+++ b/src/rpg/world/WorldData.java
@@ -8,34 +8,33 @@ public class WorldData {
         switch (zone) {
             case 1:
                 return new ZoneConfig(
-                    "School Rooftop", // ✅ updated name
-                    new Enemy[]{
-                        new Enemy("Wolf", 40, 8, 12, 15),
-                        new Enemy("Boar", 50, 10, 14, 18),
-                        new Enemy("Crystal Creature", 60, 12, 16, 20)
-                    },
-                    // Mini‑boss for Zone 1
-                    new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40),
-                    // Starter weapon reward
-                    new Weapon("Pencil Blade", 8, 12, 0.05, 1.5)
-                );
+                        "School Rooftop", // ✅ updated name
+                        new Enemy[] {
+                                new Enemy("Stray Wolf", 40, 8, 12, 15), // feral, scavenging predator
+                                new Enemy("Feral Boar", 50, 10, 14, 18), // aggressive, territorial beast
+                                new Enemy("Crystal-Scarred Crow", 45, 9, 13, 16), // rooftop scavenger mutated by shards
+                                new Enemy("Lesser Crystal Golem", 60, 12, 16, 20) // early hint of lab crystal
+                                                                                  // experiments
+                        },
+                        // Mini‑boss for Zone 1
+                        new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40),
+                        // Starter weapon reward
+                        new Weapon("Pencil Blade", 8, 12, 0.05, 1.5));
             case 2:
                 return new ZoneConfig(
-                    "Forest Clearing",
-                    new Enemy[]{
-                        new Enemy("Forest Wolf", 55, 10, 14, 20),
-                        new Enemy("Ent Guardian", 80, 14, 20, 30)
-                    },
-                    new Enemy("Forest Guardian", 180, 20, 30, 60),
-                    new Weapon("Rusty Sword", 12, 18, 0.08, 1.5)
-                );
+                        "Forest Clearing",
+                        new Enemy[] {
+                                new Enemy("Forest Wolf", 55, 10, 14, 20),
+                                new Enemy("Ent Guardian", 80, 14, 20, 30)
+                        },
+                        new Enemy("Forest Guardian", 180, 20, 30, 60),
+                        new Weapon("Rusty Sword", 12, 18, 0.08, 1.5));
             default:
                 return new ZoneConfig(
-                    "Unknown Wasteland",
-                    new Enemy[]{ new Enemy("Shadow Spawn", 70, 15, 20, 30) },
-                    new Enemy("Ancient Horror", 250, 25, 35, 70),
-                    null
-                );
+                        "Unknown Wasteland",
+                        new Enemy[] { new Enemy("Shadow Spawn", 70, 15, 20, 30) },
+                        new Enemy("Ancient Horror", 250, 25, 35, 70),
+                        null);
         }
     }
 }

--- a/src/rpg/world/WorldData.java
+++ b/src/rpg/world/WorldData.java
@@ -13,7 +13,7 @@ public class WorldData {
                                 new Enemy("Stray Wolf", 40, 8, 12, 15), // feral, scavenging predator
                                 new Enemy("Feral Boar", 50, 10, 14, 18), // aggressive, territorial beast
                                 new Enemy("Crystal-Scarred Crow", 45, 9, 13, 16), // rooftop scavenger mutated by shards
-                                new Enemy("Lesser Crystal Golem", 60, 12, 16, 20) // early hint of lab crystal
+                                new Enemy("Lesser Crystal Golem", 60, 12, 16, 20) // early hint of lab crystal //
                                                                                   // experiments
                         },
                         // Mini‑boss for Zone 1
@@ -22,13 +22,13 @@ public class WorldData {
                         new Weapon("Pencil Blade", 8, 12, 0.05, 1.5));
             case 2:
                 return new ZoneConfig(
-                        "Forest Clearing",
+                        "Ruined Lab", // ✅ updated name
                         new Enemy[] {
-                                new Enemy("Forest Wolf", 55, 10, 14, 20),
-                                new Enemy("Ent Guardian", 80, 14, 20, 30)
+                                new Enemy("Fractured Homunculus", 55, 10, 14, 20), // twisted bio‑experiment
+                                new Enemy("Shattered Automaton", 80, 14, 20, 30) // broken lab robot
                         },
-                        new Enemy("Forest Guardian", 180, 20, 30, 60),
-                        new Weapon("Rusty Sword", 12, 18, 0.08, 1.5));
+                        new Enemy("Aberrant Chimera", 180, 20, 30, 60), // zone boss: grotesque fusion
+                        new Weapon("Prototype Blade", 12, 18, 0.08, 1.5));
             default:
                 return new ZoneConfig(
                         "Unknown Wasteland",


### PR DESCRIPTION


### Changes
- **Safe Zone System**
  - Added `SafeZone` interface and `SafeZoneFactory`
  - Implemented `RooftopSafeZone` (Zone 1) with immersive rooftop environment text
  - Implemented `RuinedLabSafeZone` (Zone 2) with Professor Ashiro + Scrapwright Kuro intro and shop unlock
  - Updated `SafeZoneSystem` to delegate to `SafeZoneFactory`
  - Added `searchSafeZone()` → blocks searching inside safe zones

- **Zone 1 (School Rooftop)**
  - Enhanced narrative: cracked tiles, rusted fence, frozen classmates below
  - Objective text updated: secure food and craft a weapon

- **Zone 2 (Ruined Lab)**
  - NPC dialogue and shop unlock sequence integrated
  - Shop accessible globally after first encounter

- **Combat System**
  - Removed generic loot placeholder line
  - Calls `LootSystem.dropLoot(state)` directly after victory
  - Boss reward (Revival Potion) displayed separately
  - Resets `state.lootDisplayed = false` at combat start

- **Loot System**
  - Added guard with `state.lootDisplayed` to prevent duplicate loot messages
  - Prints `"📦 Loot acquired:"` header once per combat
  - Each item shown on its own line only if actually dropped
  - Recipes displayed with ✨ marker
  - Example:
    ```
    📦 Loot acquired:
      + 2 Shards
      + 1 Meat
      ✨ Iron Sword Recipe
    ```

- **GameState**
  - Added `public boolean lootDisplayed = false;` to control loot printing
  - Existing fields expanded for future-proofing (zone intros, shop unlocks, skills, crafting