### PR TITLE
Supporter System Implementation & Tutorial Enforcement

### DIFF
--- a/src/rpg/characters/Player.java
+++ b/src/rpg/characters/Player.java
@@ -60,9 +60,9 @@ public class Player {
 
                 // 🆕 Newly added - Skills
                 this.skills = new Skill[] {
-                    ScientistSkills.chemicalStrike,
-                    ScientistSkills.plasmaField,
-                    ScientistSkills.nuclearBlast
+                        ScientistSkills.chemicalStrike,
+                        ScientistSkills.plasmaField,
+                        ScientistSkills.nuclearBlast
                 };
                 break;
 
@@ -73,9 +73,9 @@ public class Player {
 
                 // 🆕 Newly added - Skills
                 this.skills = new Skill[] {
-                    FighterSkills.powerPunch,
-                    FighterSkills.warCry,
-                    FighterSkills.earthBreaker
+                        FighterSkills.powerPunch,
+                        FighterSkills.warCry,
+                        FighterSkills.earthBreaker
                 };
                 break;
 
@@ -86,9 +86,9 @@ public class Player {
 
                 // 🆕 Newly added - Skills
                 this.skills = new Skill[] {
-                    ArchmageSkills.fireBolt,
-                    ArchmageSkills.arcaneShield,
-                    ArchmageSkills.meteorStorm
+                        ArchmageSkills.fireBolt,
+                        ArchmageSkills.arcaneShield,
+                        ArchmageSkills.meteorStorm
                 };
                 break;
 
@@ -245,4 +245,14 @@ public class Player {
             System.out.println("✨ Level Up! " + name + " is now Level " + level + "!");
         }
     }
+
+    // Partial heal method
+    public void heal(int amount) {
+        if (amount <= 0)
+            return; // ignore invalid heals
+        int beforeHp = hp;
+        hp = Math.min(maxHp, hp + amount);
+        System.out.println("❤️ " + name + " healed for " + (hp - beforeHp) + " HP!");
+    }
+
 }

--- a/src/rpg/characters/Supporter.java
+++ b/src/rpg/characters/Supporter.java
@@ -3,22 +3,42 @@ package rpg.characters;
 public class Supporter {
     private String name;
     private String trait;
+    private boolean revived;     // whether this supporter has been revived
+    private String ability;      // unique ability or buff they provide
+    private int hp;              // optional: health if they can fight
+    private int power;           // optional: support strength (buff/heal amount)
 
-    public Supporter(String name, String trait) {
+    public Supporter(String name, String trait, String ability) {
         this.name = name;
         this.trait = trait;
+        this.ability = ability;
+        this.revived = false;
+        this.hp = 100;   // default values, can be tuned
+        this.power = 10;
     }
 
-    public String getName() {
-        return name;
+    // --- Getters ---
+    public String getName() { return name; }
+    public String getTrait() { return trait; }
+    public String getAbility() { return ability; }
+    public boolean isRevived() { return revived; }
+    public int getHp() { return hp; }
+    public int getPower() { return power; }
+
+    // --- Setters / State changes ---
+    public void setRevived(boolean revived) {
+        this.revived = revived;
     }
 
-    public String getTrait() {
-        return trait;
+    public void healPlayer(rpg.characters.Player player) {
+        if (revived) {
+            player.heal(power);
+            System.out.println(name + " uses " + ability + " to heal you for " + power + " HP!");
+        }
     }
 
     @Override
     public String toString() {
-        return name + " the " + trait;
+        return (revived ? "✅ " : "❌ ") + name + " the " + trait + " (" + ability + ")";
     }
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -1,10 +1,13 @@
 package rpg.game;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.Map;
 import rpg.characters.Enemy;
+import rpg.characters.Supporter;
 
 public class GameState {
     public int zone = 1;
@@ -36,5 +39,7 @@ public class GameState {
     public boolean lootDisplayed = false;   // ✅ already added, prevents duplicate loot text
 
     public boolean metSirKhai = false;
+    public List<Supporter> supporters = new ArrayList<>();
+
 
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -37,7 +37,6 @@ public class GameState {
     public boolean skillsUnlocked = false;
 
     public boolean lootDisplayed = false;   // ✅ already added, prevents duplicate loot text
-
     public boolean metSirKhai = false;
     public List<Supporter> supporters = new ArrayList<>();
 

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -35,4 +35,6 @@ public class GameState {
 
     public boolean lootDisplayed = false;   // ✅ already added, prevents duplicate loot text
 
+    public boolean metSirKhai = false;
+
 }

--- a/src/rpg/systems/CombatSystem.java
+++ b/src/rpg/systems/CombatSystem.java
@@ -146,23 +146,9 @@ public class CombatSystem {
         }
 
         // --- Outcome ---
+        // --- Outcome ---
         if (player.isAlive()) {
             TextEffect.typeWriter("🎉 You defeated the " + enemy.getName() + "!", 50);
-
-            if (enemy == state.currentZoneBoss) {
-                state.revivalPotions++;
-                TextEffect.typeWriter("✨ As the boss falls, you discover a glowing Revival Potion!", 50);
-
-                if (!state.metSirKhai) { // add this flag in GameState
-                    TextEffect.typeWriter("\n👨‍🏫 [Sir Khai] You fought bravely... I’ve been waiting for you here.",
-                            60);
-                    TextEffect.typeWriter("His presence steadies your nerves — a mentor figure in this frozen world.",
-                            60);
-                    TextEffect.typeWriter("Objective Updated: Speak with Sir Khai to learn your next path.", 60);
-
-                    state.metSirKhai = true;
-                }
-            }
 
             LootSystem.dropLoot(state);
 
@@ -176,5 +162,6 @@ public class CombatSystem {
             player.healFull();
             return false;
         }
+
     }
 }

--- a/src/rpg/systems/CombatSystem.java
+++ b/src/rpg/systems/CombatSystem.java
@@ -5,7 +5,7 @@ import java.util.Random;
 import rpg.utils.TextEffect;
 import rpg.characters.Player;
 import rpg.characters.Enemy;
-import rpg.skills.Skill; 
+import rpg.skills.Skill;
 import rpg.items.Consumable;
 import rpg.items.Weapon;
 import rpg.game.GameState;
@@ -109,7 +109,8 @@ public class CombatSystem {
 
                         case "kill":
                             enemy.takeDamage(enemy.getHp());
-                            TextEffect.typeWriter("💀 [DEV] You unleash a hidden power... the enemy is instantly slain!", 40);
+                            TextEffect.typeWriter(
+                                    "💀 [DEV] You unleash a hidden power... the enemy is instantly slain!", 40);
                             break;
 
                         default:
@@ -120,10 +121,12 @@ public class CombatSystem {
                     if (enemy.isAlive()) {
                         try {
                             int dmgTaken = enemy.enemyAction();
-                            if (defended) dmgTaken /= 2;
+                            if (defended)
+                                dmgTaken /= 2;
 
                             int actualDamage = player.takeDamage(dmgTaken);
-                            TextEffect.typeWriter("The " + enemy.getName() + " attacks! You take " + actualDamage + " damage.", 40);
+                            TextEffect.typeWriter(
+                                    "The " + enemy.getName() + " attacks! You take " + actualDamage + " damage.", 40);
                         } catch (Exception e) {
                             TextEffect.typeWriter("The enemy falters in its attack.", 40);
                             System.err.println("Enemy action error -> " + e.getMessage());
@@ -149,6 +152,16 @@ public class CombatSystem {
             if (enemy == state.currentZoneBoss) {
                 state.revivalPotions++;
                 TextEffect.typeWriter("✨ As the boss falls, you discover a glowing Revival Potion!", 50);
+
+                if (!state.metSirKhai) { // add this flag in GameState
+                    TextEffect.typeWriter("\n👨‍🏫 [Sir Khai] You fought bravely... I’ve been waiting for you here.",
+                            60);
+                    TextEffect.typeWriter("His presence steadies your nerves — a mentor figure in this frozen world.",
+                            60);
+                    TextEffect.typeWriter("Objective Updated: Speak with Sir Khai to learn your next path.", 60);
+
+                    state.metSirKhai = true;
+                }
             }
 
             LootSystem.dropLoot(state);

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -9,6 +9,7 @@ import rpg.utils.TextEffect;
 import rpg.game.GameState;
 import rpg.world.ZoneConfig;
 import rpg.world.WorldData;
+import rpg.world.SupporterPool; // 🆕 import the supporter pool
 
 public class ExplorationSystem {
 
@@ -49,13 +50,17 @@ public class ExplorationSystem {
                     state.skillsUnlocked = true;
                 }
 
+                // 🆕 Random statue encounter after Stage 1
                 if (state.zone > 1) { // only after Stage 1
                     int chance = rand.nextInt(100);
                     if (chance < 10) { // 10% chance per forward step
-                        Supporter statue = new Supporter("Aurelia", "Guardian", "Idk");
-                        TextEffect.typeWriter("🗿 A mysterious statue appears in the frozen wasteland...", 60);
-                        ReviveSystem.randomRevive(state, statue);
-                        return; // skip normal mob/boss encounter this step
+                        Supporter statue = SupporterPool.getRandomSupporter(state.zone, rand);
+                        if (statue != null) {
+                            TextEffect.typeWriter("🗿 A mysterious statue appears in the "
+                                    + zone.name + "...", 60);
+                            ReviveSystem.randomRevive(state, statue);
+                            return;
+                        }
                     }
                 }
 

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -75,6 +75,17 @@ public class ExplorationSystem {
                         if (win) {
                             TextEffect.typeWriter(
                                     "🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+
+                            // Tutorial: miniboss drops Revival Potion
+                            TextEffect.typeWriter("✨ As the boss falls, you discover a glowing Revival Potion!", 60);
+                            state.revivalPotions++;
+
+                            // Scripted Sir Khai statue event
+                            if (state.zone == 1 && !state.metSirKhai) {
+                                Supporter sirKhai = new Supporter("Sir Khai", "Teacher", "Guidance");
+                                ReviveSystem.scriptedRevive(state, sirKhai, scanner);
+                            }
+
                             state.zone++;
                             state.forwardSteps = 0;
                             state.inSafeZone = true;

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -3,6 +3,7 @@ package rpg.systems;
 import java.util.Scanner;
 import java.util.Random;
 import rpg.characters.Player;
+import rpg.characters.Supporter;
 import rpg.characters.Enemy;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
@@ -48,6 +49,16 @@ public class ExplorationSystem {
                     state.skillsUnlocked = true;
                 }
 
+                if (state.zone > 1) { // only after Stage 1
+                    int chance = rand.nextInt(100);
+                    if (chance < 10) { // 10% chance per forward step
+                        Supporter statue = new Supporter("Aurelia", "Guardian", "Idk");
+                        TextEffect.typeWriter("🗿 A mysterious statue appears in the frozen wasteland...", 60);
+                        ReviveSystem.randomRevive(state, statue);
+                        return; // skip normal mob/boss encounter this step
+                    }
+                }
+
                 if (state.forwardSteps >= 5) {
                     try {
                         if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
@@ -57,7 +68,8 @@ public class ExplorationSystem {
                         CombatSystem combat = new CombatSystem(state);
                         boolean win = combat.startCombat(player, zone.boss);
                         if (win) {
-                            TextEffect.typeWriter("🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+                            TextEffect.typeWriter(
+                                    "🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
                             state.zone++;
                             state.forwardSteps = 0;
                             state.inSafeZone = true;

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -2,47 +2,64 @@ package rpg.systems;
 
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
+import rpg.characters.Supporter;
 
 import java.util.Scanner;
-
-import rpg.characters.Supporter;
 
 public class ReviveSystem {
 
     // Scripted revival (e.g., Sir Khai after Stage 1 miniboss)
     public static void scriptedRevive(GameState state, Supporter sirKhai, Scanner scanner) {
         while (!state.metSirKhai) {
-            TextEffect.typeWriter("\n🗿 A statue stands before you... Sir Khai, frozen in stone.", 60);
-            TextEffect.typeWriter("A glowing aura surrounds him. Do you wish to revive? (yes/no)", 60);
+            try {
+                TextEffect.typeWriter("\n🗿 A statue stands before you... Sir Khai, frozen in stone.", 60);
+                TextEffect.typeWriter("A glowing aura surrounds him. Do you wish to revive? (yes/no)", 60);
 
-            System.out.print("> ");
-            String choice = scanner.nextLine().trim().toLowerCase();
+                System.out.print("> ");
+                String choice = scanner.nextLine().trim().toLowerCase();
 
-            if (choice.equals("yes")) {
-                if (state.revivalPotions > 0) {
-                    state.revivalPotions--;
-                    sirKhai.setRevived(true);
-                    state.supporters.add(sirKhai);
-                    state.metSirKhai = true;
-                    TextEffect.typeWriter("✨ Sir Khai awakens, joining you as your first supporter!", 60);
-                } else {
-                    TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
+                switch (choice) {
+                    case "yes":
+                        if (state.revivalPotions > 0) {
+                            state.revivalPotions--;
+                            sirKhai.setRevived(true);
+                            state.supporters.add(sirKhai);
+                            state.metSirKhai = true;
+                            TextEffect.typeWriter("✨ Sir Khai awakens, joining you as your first supporter!", 60);
+                        } else {
+                            TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
+                        }
+                        break;
+
+                    case "no":
+                        TextEffect.typeWriter("❌ You cannot proceed without reviving a supporter.", 60);
+                        break;
+
+                    default:
+                        TextEffect.typeWriter("⚠️ Invalid input. Please type 'yes' or 'no'.", 60);
+                        break;
                 }
-            } else {
-                TextEffect.typeWriter("❌ You cannot proceed without reviving a supporter.", 60);
+            } catch (Exception e) {
+                TextEffect.typeWriter("An error occurred while processing your choice.", 60);
+                System.err.println("ReviveSystem error -> " + e.getMessage());
             }
         }
     }
 
     // Random statue revival outside safe zones
     public static void randomRevive(GameState state, Supporter supporter) {
-        if (state.revivalPotions > 0) {
-            state.revivalPotions--;
-            supporter.setRevived(true);
-            TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
-            state.supporters.add(supporter); // track revived allies
-        } else {
-            TextEffect.typeWriter("You sense a presence... but you lack a Revival Potion.", 60);
+        try {
+            if (state.revivalPotions > 0) {
+                state.revivalPotions--;
+                supporter.setRevived(true);
+                TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
+                state.supporters.add(supporter); // track revived allies
+            } else {
+                TextEffect.typeWriter("🗿 The statue remains silent... you lack a Revival Potion.", 60);
+            }
+        } catch (Exception e) {
+            TextEffect.typeWriter("An error occurred during statue revival.", 60);
+            System.err.println("RandomRevive error -> " + e.getMessage());
         }
     }
 }

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -1,0 +1,27 @@
+package rpg.systems;
+
+import rpg.utils.TextEffect;
+import rpg.game.GameState;
+import rpg.characters.Supporter;
+
+public class ReviveSystem {
+
+    // Scripted revival (e.g., Sir Khai after Stage 1 miniboss)
+    public static void scriptedRevive(GameState state, String npcName) {
+        TextEffect.typeWriter("\n👨‍🏫 [" + npcName + "] You fought bravely... I’ve been waiting for you here.", 60);
+        TextEffect.typeWriter("Objective Updated: Speak with " + npcName + " to learn your next path.", 60);
+        state.metSirKhai = true; // flag in GameState
+    }
+
+    // Random statue revival outside safe zones
+    public static void randomRevive(GameState state, Supporter supporter) {
+        if (state.revivalPotions > 0) {
+            state.revivalPotions--;
+            supporter.setRevived(true);
+            TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
+            state.supporters.add(supporter); // track revived allies
+        } else {
+            TextEffect.typeWriter("You sense a presence... but you lack a Revival Potion.", 60);
+        }
+    }
+}

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -2,15 +2,36 @@ package rpg.systems;
 
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
+
+import java.util.Scanner;
+
 import rpg.characters.Supporter;
 
 public class ReviveSystem {
 
     // Scripted revival (e.g., Sir Khai after Stage 1 miniboss)
-    public static void scriptedRevive(GameState state, String npcName) {
-        TextEffect.typeWriter("\n👨‍🏫 [" + npcName + "] You fought bravely... I’ve been waiting for you here.", 60);
-        TextEffect.typeWriter("Objective Updated: Speak with " + npcName + " to learn your next path.", 60);
-        state.metSirKhai = true; // flag in GameState
+    public static void scriptedRevive(GameState state, Supporter sirKhai, Scanner scanner) {
+        TextEffect.typeWriter("\n🗿 A statue stands before you... Sir Khai, frozen in stone.", 60);
+        TextEffect.typeWriter("A glowing aura surrounds him. Do you wish to revive? (yes/no)", 60);
+
+        System.out.print("> ");
+        String choice = scanner.nextLine().trim().toLowerCase();
+
+        if (choice.equals("yes")) {
+            if (state.revivalPotions > 0) {
+                state.revivalPotions--;
+                sirKhai.setRevived(true);
+                state.supporters.add(sirKhai);
+                state.metSirKhai = true;
+                TextEffect.typeWriter("✨ Sir Khai awakens, joining you as your first supporter!", 60);
+            } else {
+                TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
+            }
+        } else {
+            // Tutorial enforcement: must revive at least one supporter
+            TextEffect.typeWriter("❌ You cannot proceed without reviving a supporter.", 60);
+            scriptedRevive(state, sirKhai, scanner); // re‑prompt until valid
+        }
     }
 
     // Random statue revival outside safe zones

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -11,26 +11,26 @@ public class ReviveSystem {
 
     // Scripted revival (e.g., Sir Khai after Stage 1 miniboss)
     public static void scriptedRevive(GameState state, Supporter sirKhai, Scanner scanner) {
-        TextEffect.typeWriter("\n🗿 A statue stands before you... Sir Khai, frozen in stone.", 60);
-        TextEffect.typeWriter("A glowing aura surrounds him. Do you wish to revive? (yes/no)", 60);
+        while (!state.metSirKhai) {
+            TextEffect.typeWriter("\n🗿 A statue stands before you... Sir Khai, frozen in stone.", 60);
+            TextEffect.typeWriter("A glowing aura surrounds him. Do you wish to revive? (yes/no)", 60);
 
-        System.out.print("> ");
-        String choice = scanner.nextLine().trim().toLowerCase();
+            System.out.print("> ");
+            String choice = scanner.nextLine().trim().toLowerCase();
 
-        if (choice.equals("yes")) {
-            if (state.revivalPotions > 0) {
-                state.revivalPotions--;
-                sirKhai.setRevived(true);
-                state.supporters.add(sirKhai);
-                state.metSirKhai = true;
-                TextEffect.typeWriter("✨ Sir Khai awakens, joining you as your first supporter!", 60);
+            if (choice.equals("yes")) {
+                if (state.revivalPotions > 0) {
+                    state.revivalPotions--;
+                    sirKhai.setRevived(true);
+                    state.supporters.add(sirKhai);
+                    state.metSirKhai = true;
+                    TextEffect.typeWriter("✨ Sir Khai awakens, joining you as your first supporter!", 60);
+                } else {
+                    TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
+                }
             } else {
-                TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
+                TextEffect.typeWriter("❌ You cannot proceed without reviving a supporter.", 60);
             }
-        } else {
-            // Tutorial enforcement: must revive at least one supporter
-            TextEffect.typeWriter("❌ You cannot proceed without reviving a supporter.", 60);
-            scriptedRevive(state, sirKhai, scanner); // re‑prompt until valid
         }
     }
 

--- a/src/rpg/world/SupporterPool.java
+++ b/src/rpg/world/SupporterPool.java
@@ -1,0 +1,35 @@
+package rpg.world;
+
+import java.util.*;
+import rpg.characters.Supporter;
+
+public class SupporterPool {
+    private static final Map<Integer, List<Supporter>> pool = new HashMap<>();
+
+    static {
+        // Stage 1 – School Rooftop
+        pool.put(1, Arrays.asList(
+            new Supporter("Sir Khai", "Teacher", "Guidance"), // scripted, but kept here for consistency
+            new Supporter("Aya", "Strategist", "Encouragement")
+        ));
+
+        // Stage 2 – Ruined Lab
+        pool.put(2, Arrays.asList(
+            new Supporter("Lira", "Scientist", "Chemical Aid"),
+            new Supporter("Ryo", "Inventor", "Repair")
+        ));
+
+        // Stage 3 – City Ruins
+        pool.put(3, Arrays.asList(
+            new Supporter("Hana", "Medic", "First Aid"),
+            new Supporter("Daisuke", "Guardian", "Shield Wall"),
+            new Supporter("Kael", "Merchant", "Resourceful")
+        ));
+    }
+
+    public static Supporter getRandomSupporter(int zone, Random rand) {
+        List<Supporter> supporters = pool.get(zone);
+        if (supporters == null || supporters.isEmpty()) return null;
+        return supporters.get(rand.nextInt(supporters.size()));
+    }
+}

--- a/src/rpg/world/WorldData.java
+++ b/src/rpg/world/WorldData.java
@@ -8,30 +8,32 @@ public class WorldData {
         switch (zone) {
             case 1:
                 return new ZoneConfig(
-                        "School Rooftop", // ✅ updated name
+                        "School Rooftop", // name
+                        "The rooftop safe zone, overlooking the frozen campus.", // description
                         new Enemy[] {
-                                new Enemy("Stray Wolf", 40, 8, 12, 15), // feral, scavenging predator
-                                new Enemy("Feral Boar", 50, 10, 14, 18), // aggressive, territorial beast
-                                new Enemy("Crystal-Scarred Crow", 45, 9, 13, 16), // rooftop scavenger mutated by shards
-                                new Enemy("Lesser Crystal Golem", 60, 12, 16, 20) // early hint of lab crystal //
-                                                                                  // experiments
+                                new Enemy("Stray Wolf", 40, 8, 12, 15),
+                                new Enemy("Feral Boar", 50, 10, 14, 18),
+                                new Enemy("Crystal-Scarred Crow", 45, 9, 13, 16),
+                                new Enemy("Lesser Crystal Golem", 60, 12, 16, 20)
                         },
-                        // Mini‑boss for Zone 1
                         new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40),
-                        // Starter weapon reward
                         new Weapon("Pencil Blade", 8, 12, 0.05, 1.5));
+
             case 2:
                 return new ZoneConfig(
-                        "Ruined Lab", // ✅ updated name
+                        "Ruined Lab",
+                        "Shattered corridors filled with failed experiments.",
                         new Enemy[] {
-                                new Enemy("Fractured Homunculus", 55, 10, 14, 20), // twisted bio‑experiment
-                                new Enemy("Shattered Automaton", 80, 14, 20, 30) // broken lab robot
+                                new Enemy("Fractured Homunculus", 55, 10, 14, 20),
+                                new Enemy("Shattered Automaton", 80, 14, 20, 30)
                         },
-                        new Enemy("Aberrant Chimera", 180, 20, 30, 60), // zone boss: grotesque fusion
+                        new Enemy("Aberrant Chimera", 180, 20, 30, 60),
                         new Weapon("Prototype Blade", 12, 18, 0.08, 1.5));
+
             default:
                 return new ZoneConfig(
                         "Unknown Wasteland",
+                        "test",
                         new Enemy[] { new Enemy("Shadow Spawn", 70, 15, 20, 30) },
                         new Enemy("Ancient Horror", 250, 25, 35, 70),
                         null);

--- a/src/rpg/world/ZoneConfig.java
+++ b/src/rpg/world/ZoneConfig.java
@@ -4,12 +4,14 @@ import rpg.characters.Enemy;
 import rpg.items.Weapon;
 
 public class ZoneConfig {
-    public final String description;
+    public final String name;         // short label
+    public final String description;  // longer flavor text
     public final Enemy[] mobs;
     public final Enemy boss;
     public final Weapon searchLoot;
 
-    public ZoneConfig(String description, Enemy[] mobs, Enemy boss, Weapon searchLoot) {
+    public ZoneConfig(String name, String description, Enemy[] mobs, Enemy boss, Weapon searchLoot) {
+        this.name = name;
         this.description = description;
         this.mobs = mobs;
         this.boss = boss;


### PR DESCRIPTION
## Summary
This PR introduces and refines the **Supporter System**. Supporters are silent statues that can be revived using Revival Potions. The **Sir Khai tutorial event** is mandatory after the Stage 1 miniboss, teaching the player how to revive supporters. Later statues remain optional. Input handling has been improved with validation and error catching.

---

## Key Changes
- **`Supporter.java`**
  - Defines supporter attributes (`name`, `trait`, `ability`, `revived`).
  - Includes healing logic and state management.
  - **Future extension:** add equip/unequip methods, enforce max 3 equipped supporters.

- **`GameState.java`**
  - Tracks `revivalPotions`.
  - Tracks revived supporters (`supporters` list).
  - Tracks tutorial flag (`metSirKhai`).
  - **Future extension:** add `equippedSupporters` list with max size 3.

- **`ReviveSystem.java`**
  - **`scriptedRevive`**: mandatory Sir Khai revival after Stage 1 miniboss.
    - Prompts player with yes/no choice.
    - Requires potion, enforces tutorial until revived.
    - Uses loop + error handling for safe input.
  - **`randomRevive`**: optional statue revival outside safe zones.
    - Consumes potion if available, otherwise statue remains silent.
    - Wrapped in try/catch for error safety.

- **`ExplorationSystem.java`**
  - Handles zone progression.
  - After Stage 1 miniboss defeat:
    - Drops Revival Potion.
    - Calls `ReviveSystem.scriptedRevive` for Sir Khai.
  - Random statue encounters (after Stage 1) use `SupporterPool`.

- **`SupporterPool.java`**
  - Zone‑based supporter lookup table.
  - Maps zone IDs → supporter lists.
  - Sir Khai is scripted, not random.
  - **Future extension:** add new supporters per zone.

- **`CombatSystem.java`**
  - Cleaned up outcome logic: no duplicate potion drops or Sir Khai revival.
  - Focuses purely on combat resolution (win/lose, EXP, loot).

- **`ZoneConfig.java` & `WorldData.java`**
  - Updated to include both `name` and `description`.
  - Clarified zone progression: safe zones are hubs, hostile zones are paths toward the next landmark.


## Impact
- Statues are silent, consistent with narrative.
- Sir Khai tutorial enforced: player must revive him with the miniboss‑dropped potion.
- Random statues remain optional.
- Input handling improved: invalid responses prompt retry, errors are caught safely.
- Clean separation of responsibilities:
  - Combat = fights
  - Exploration = rewards/events
  - ReviveSystem = revival logic

---

## Next Steps for Team
- Add **equip/unequip mechanics** in `GameState` and `Supporter.java`.
- Enforce **maximum of 3 equipped supporters**.
- Extend `SupporterPool` with new supporter definitions per zone.
- Add UI/UX indicators for equipped vs. revived supporters.
- Implement supporter combat assists (auto‑heal, buffs, shields).
---
## Flow Visualization

```text
[CombatSystem] → handles fight only
    └─ returns win/lose

[ExplorationSystem]
    ├─ if win:
    │    ├─ drop Revival Potion
    │    ├─ if Zone 1 and Sir Khai not met → ReviveSystem.scriptedRevive
    │    └─ advance zone / safe zone
    └─ if lose:
         └─ respawn at safe zone

[ReviveSystem]
    ├─ scriptedRevive (mandatory tutorial)
    │    ├─ yes + potion → revive Sir Khai
    │    ├─ yes + no potion → blocked, re‑prompt
    │    └─ no → invalid, re‑prompt
    └─ randomRevive (optional statues)
         ├─ potion → revive supporter
         └─ no potion → statue remains silent

[GameState]
    ├─ revivalPotions
    ├─ supporters list
    └─ metSirKhai flag

