### PR TITLE
Exploration & Boss Gate System + DevSkip Mode

### DIFF
--- a/src/rpg/game/Game.java
+++ b/src/rpg/game/Game.java
@@ -35,11 +35,13 @@ public class Game {
                             TextEffect.typeWriter("Thanks for playing!", 40);
                             running = false;
                             break;
-                        case "devskip": // developer command (hidden)
+                        case "devskip":
                             System.out.println(">> Developer shortcut: skipping intro...");
+                            TextEffect.fastMode = true; // 🆕 enable fast mode globally
                             createPlayer();
                             new Tutorial(player, state, scanner, rand).start();
                             break;
+
                         default:
                             TextEffect.typeWriter("Invalid choice. Please try again.", 40);
                     }
@@ -89,11 +91,6 @@ public class Game {
         TextEffect.typeWriter("You focus... Who are you in this new world?", 60);
         System.out.print("Enter your name: ");
         String name = scanner.nextLine();
-
-        // 🆕 Enable fast mode if admin123
-        if (name.equalsIgnoreCase("admin123")) {
-            state.fastMode = true;
-        }
 
         TextEffect.typeWriter("Choose your class:", 40);
 

--- a/src/rpg/game/Game.java
+++ b/src/rpg/game/Game.java
@@ -90,6 +90,11 @@ public class Game {
         System.out.print("Enter your name: ");
         String name = scanner.nextLine();
 
+        // 🆕 Enable fast mode if admin123
+        if (name.equalsIgnoreCase("admin123")) {
+            state.fastMode = true;
+        }
+
         TextEffect.typeWriter("Choose your class:", 40);
 
         // Scientist

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -70,7 +70,7 @@ public class GameLoop {
 
                     case "status":
                         try {
-                            StatusSystem.showStatus(player, state.meat, state.shards);
+                            StatusSystem.showStatus(player, state.shards, state);
                         } catch (Exception e) {
                             TextEffect.typeWriter("Unable to display status right now.", 40);
                             System.err.println("Status error -> " + e.getMessage());

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -40,5 +40,8 @@ public class GameState {
     public boolean metSirKhai = false;
     public List<Supporter> supporters = new ArrayList<>();
 
+    
+    public boolean bossGateDiscovered = false;
+
 
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -10,6 +10,7 @@ import rpg.characters.Enemy;
 import rpg.characters.Supporter;
 
 public class GameState {
+    public boolean fastMode = false;
     public int zone = 1;
     public int forwardSteps = 0;
     public int crystals = 0;
@@ -41,8 +42,6 @@ public class GameState {
     public List<Supporter> supporters = new ArrayList<>();
 
     public boolean bossGateDiscovered = false;
-    public boolean fastMode = false;
-    public static GameState current; // optional singleton reference
 
 
 }

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -13,10 +13,10 @@ public class GameState {
     public int zone = 1;
     public int forwardSteps = 0;
     public int crystals = 0;
-    public int shards = 0;         
+    public int shards = 0;
     public int meat = 0;
     public int revivalPotions = 0;
-    public Enemy currentZoneBoss; 
+    public Enemy currentZoneBoss;
     public boolean inSafeZone = false;
 
     // ✅ Track crafted stage weapons (consistent naming)
@@ -36,12 +36,13 @@ public class GameState {
     public boolean zone2IntroShown = false;
     public boolean skillsUnlocked = false;
 
-    public boolean lootDisplayed = false;   // ✅ already added, prevents duplicate loot text
+    public boolean lootDisplayed = false; // ✅ already added, prevents duplicate loot text
     public boolean metSirKhai = false;
     public List<Supporter> supporters = new ArrayList<>();
 
-    
     public boolean bossGateDiscovered = false;
+    public boolean fastMode = false;
+    public static GameState current; // optional singleton reference
 
 
 }

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -50,8 +50,11 @@ public class Tutorial {
                                 TextEffect.typeWriter("You search the school rooftop...", 60);
                                 TextEffect.typeWriter("You found: 1 Crystal, 1 Crystal Shard, and a Pencil.", 60);
 
-                                TextEffect.typeWriter("[Narrator] Crystals are rare crafting materials used to forge weapons.", 70);
-                                TextEffect.typeWriter("[Narrator] Crystal Shards, on the other hand, are a form of currency. You'll be able to spend them in shops after Safe Zone 1.", 70);
+                                TextEffect.typeWriter(
+                                        "[Narrator] Crystals are rare crafting materials used to forge weapons.", 70);
+                                TextEffect.typeWriter(
+                                        "[Narrator] Crystal Shards, on the other hand, are a form of currency. You'll be able to spend them in shops after Safe Zone 1.",
+                                        70);
 
                                 hasCrystal = true;
                                 hasPencil = true;
@@ -89,7 +92,7 @@ public class Tutorial {
                                 TextEffect.typeWriter("You can’t leave yet. You need a weapon first.", 60);
                             } else {
                                 TextEffect.typeWriter("Armed with your " + player.getWeapon().getName() +
-                                        ", you step forward into the unknown...", 80);
+                                        ",you leave the School Rooftop behind...", 80);
 
                                 TutorialCombatSystem tutorialCombat = new TutorialCombatSystem(state);
                                 Enemy tutorialEnemy = new Enemy("Wild Beast", 20, 5, 8, 15);
@@ -97,6 +100,15 @@ public class Tutorial {
                                 boolean win = tutorialCombat.startTutorialCombat(player, tutorialEnemy);
 
                                 if (win) {
+                                    TextEffect.typeWriter("✅ You overcame the Wild Beast. The path forward is clear.",
+                                            80);
+                                    TextEffect.typeWriter("⚔️ Remember: the Wild Beast was only an obstacle.", 80);
+                                    TextEffect.typeWriter(
+                                            "🎯 Your true goal is to keep moving forward until you face the Fractured Logo.",
+                                            80);
+                                    TextEffect.typeWriter(
+                                            "Defeat it to unlock the next destination — the Ruined Lab safe zone.", 80);
+
                                     awake = false;
                                     GameLoop loop = new GameLoop(player, state, scanner, rand);
                                     loop.start();

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -53,7 +53,7 @@ public class Tutorial {
                                 TextEffect.typeWriter(
                                         "[Narrator] Crystals are rare crafting materials used to forge weapons.", 70);
                                 TextEffect.typeWriter(
-                                        "[Narrator] Crystal Shards, on the other hand, are a form of currency. You'll be able to spend them in shops after Safe Zone 1.",
+                                        "[Narrator] Crystal Shards, on the other hand, are a form of currency. You'll be able to spend them in shops which unlocks further.",
                                         70);
 
                                 hasCrystal = true;
@@ -91,8 +91,6 @@ public class Tutorial {
                             if (player.getWeapon() == null) {
                                 TextEffect.typeWriter("You can’t leave yet. You need a weapon first.", 60);
                             } else {
-                                TextEffect.typeWriter("Armed with your " + player.getWeapon().getName() +
-                                        ",you leave the School Rooftop behind...", 80);
 
                                 TutorialCombatSystem tutorialCombat = new TutorialCombatSystem(state);
                                 Enemy tutorialEnemy = new Enemy("Wild Beast", 20, 5, 8, 15);
@@ -104,10 +102,10 @@ public class Tutorial {
                                             80);
                                     TextEffect.typeWriter("⚔️ Remember: the Wild Beast was only an obstacle.", 80);
                                     TextEffect.typeWriter(
-                                            "🎯 Your true goal is to keep moving forward until you face the Fractured Logo.",
+                                            "🎯 Your true goal is to keep moving forward get stronger until you face the Fractured Logo.",
                                             80);
                                     TextEffect.typeWriter(
-                                            "Defeat it to unlock the next destination — the Ruined Lab safe zone.", 80);
+                                            "Defeat it to unlock the next destination — the Ruined Lab.", 80);
 
                                     awake = false;
                                     GameLoop loop = new GameLoop(player, state, scanner, rand);

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -98,7 +98,7 @@ public class Tutorial {
                                 TextEffect.typeWriter(
                                         "🎯 Goal: Continue forward and get stronger until you face the Fractured Logo to unlock the Ruined Lab.",
                                         80);
-                                        state.forwardSteps++;
+                                state.forwardSteps++;
 
                                 TutorialCombatSystem tutorialCombat = new TutorialCombatSystem(state);
                                 Enemy tutorialEnemy = new Enemy("Wild Beast", 20, 5, 8, 15);

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -128,7 +128,7 @@ public class Tutorial {
 
                     case "status":
                         try {
-                            StatusSystem.showStatus(player, state.crystals, state.meat);
+                            StatusSystem.showStatus(player, state.shards, state);
                         } catch (Exception e) {
                             TextEffect.typeWriter("Unable to display status right now.", 40);
                             System.err.println("Status error -> " + e.getMessage());

--- a/src/rpg/game/Tutorial.java
+++ b/src/rpg/game/Tutorial.java
@@ -92,6 +92,14 @@ public class Tutorial {
                                 TextEffect.typeWriter("You can’t leave yet. You need a weapon first.", 60);
                             } else {
 
+                                TextEffect.typeWriter("🌌 You leave the safety of the School Rooftop behind...", 80);
+                                TextEffect.typeWriter(
+                                        "The path ahead winds through shattered classrooms and broken halls.", 80);
+                                TextEffect.typeWriter(
+                                        "🎯 Goal: Continue forward and get stronger until you face the Fractured Logo to unlock the Ruined Lab.",
+                                        80);
+                                        state.forwardSteps++;
+
                                 TutorialCombatSystem tutorialCombat = new TutorialCombatSystem(state);
                                 Enemy tutorialEnemy = new Enemy("Wild Beast", 20, 5, 8, 15);
 

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -28,146 +28,223 @@ public class ExplorationSystem {
             System.out.print("> ");
             String dir = scanner.nextLine();
 
-            switch (dir.toLowerCase()) {
-                case "backward":
-                    handleBackward(state, safeZoneAction);
-                    break;
-
-                case "forward":
-                    handleForward(player, scanner, rand, state, zone);
-                    break;
-
-                case "boss":
-                    handleBoss(player, scanner, state, zone, safeZoneAction);
-                    break;
-
-                default:
-                    TextEffect.typeWriter("Invalid direction.", 40);
+            // 🆕 If boss gate discovered, interpret numeric input
+            if (state.forwardSteps >= 5 && state.bossGateDiscovered) {
+                switch (dir) {
+                    case "1": // Safe Zone
+                        handleBackward(state, safeZoneAction, zone, player, rand);
+                        break;
+                    case "2": // Farm
+                        handleForward(player, scanner, rand, state, zone);
+                        break;
+                    case "3": // Boss
+                        handleBoss(player, scanner, state, zone, safeZoneAction, rand);
+                        break;
+                    default:
+                        TextEffect.typeWriter("Invalid choice. Please enter 1, 2, or 3.", 40);
+                }
+            } else {
+                // Before discovery → text commands
+                switch (dir.toLowerCase()) {
+                    case "backward":
+                        handleBackward(state, safeZoneAction, zone, player, rand);
+                        break;
+                    case "forward":
+                        handleForward(player, scanner, rand, state, zone);
+                        break;
+                    default:
+                        TextEffect.typeWriter("Invalid direction.", 40);
+                }
             }
 
         } catch (Exception e) {
             TextEffect.typeWriter("An unexpected error occurred while exploring.", 40);
             System.err.println("Exploration error -> " + e.getMessage());
-        } finally {
-            // Always runs after exploration attempt
-            // Could be used for logging or ensuring state consistency
         }
     }
 
     // --- Prompt ---
 
     private static void showPrompt(GameState state) {
-        if (state.forwardSteps >= 5) {
-            TextEffect.typeWriter("Do you move backward, forward, or challenge the boss? (backward/forward/boss)", 40);
+        if (state.forwardSteps >= 5 && state.bossGateDiscovered) {
+            // After gate discovery → numeric menu
+            TextEffect.typeWriter("Choose your action:\n1) Enter Safe Zone\n2) Farm\n3) Challenge Boss", 40);
         } else {
-            TextEffect.typeWriter("Do you move backward or forward? (backward/forward)", 40);
+            // Before discovery → step-based exploration
+            TextEffect.typeWriter("Do you move forward or backward? (forward/backward)", 40);
         }
     }
 
     // --- Backward / Safe zone ---
 
-    private static void handleBackward(GameState state, Runnable safeZoneAction) {
+    private static void handleBackward(GameState state, Runnable safeZoneAction,
+            ZoneConfig zone, Player player, Random rand) {
         try {
-            state.inSafeZone = true;
-            safeZoneAction.run();
+            if (state.bossGateDiscovered) {
+                // After boss gate discovery → mostly safe retreat, but small chance of mob
+                int chance = rand.nextInt(100);
+                if (chance < 10) { // 10% chance
+                    Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
+                    TextEffect.typeWriter("⚠️ An enemy suddenly blocks your retreat!", 60);
+                    CombatSystem combat = new CombatSystem(state);
+                    if (combat.startCombat(player, mob)) {
+                        LootSystem.dropLoot(state);
+                    }
+                } else {
+                    TextEffect.typeWriter("🏃 You retreat swiftly back to the safe zone.", 60);
+                }
+                state.inSafeZone = true;
+                safeZoneAction.run();
+                return;
+            }
+
+            // Before gate discovery → step-based retreat
+            if (state.forwardSteps > 0) {
+                state.forwardSteps--; // decrement steps
+                TextEffect.typeWriter("🔙 You retrace your steps cautiously...", 50);
+
+                if (state.forwardSteps == 0) {
+                    state.inSafeZone = true;
+                    TextEffect.typeWriter("🏠 You have returned safely to the safe zone.", 60);
+                    safeZoneAction.run();
+                } else {
+                    // 🆕 Chance-based encounter (e.g., 40% chance)
+                    if (rand.nextInt(100) < 40) {
+                        Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
+                        TextEffect.typeWriter("⚔️ A " + mob.getName() + " lurks in the shadows as you retreat!", 60);
+                        CombatSystem combat = new CombatSystem(state);
+                        if (combat.startCombat(player, mob)) {
+                            LootSystem.dropLoot(state);
+                        }
+                    } else {
+                        TextEffect.typeWriter("The path is eerily quiet... you slip back without incident.", 50);
+                    }
+                }
+            } else {
+                // Already at safe zone
+                state.inSafeZone = true;
+                safeZoneAction.run();
+            }
         } catch (Exception e) {
-            TextEffect.typeWriter("Something went wrong entering the safe zone.", 40);
-            System.err.println("Safe zone error -> " + e.getMessage());
+            TextEffect.typeWriter("Something went wrong while retreating.", 40);
+            System.err.println("Backward error -> " + e.getMessage());
         }
     }
 
     // --- Forward / Exploration ---
 
     private static void handleForward(Player player, Scanner scanner, Random rand,
-                                      GameState state, ZoneConfig zone) {
+            GameState state, ZoneConfig zone) {
         state.inSafeZone = false;
-        state.forwardSteps++;
 
-        // Narration on first step out of the safe zone for the current stage
+        // 🆕 If boss gate already discovered, forward becomes farm
+        if (state.bossGateDiscovered) {
+            spawnMob(state, zone, player, rand);
+            return;
+        }
+
+        // Normal exploration before gate discovery
+        state.forwardSteps++;
         narrateZoneExit(state);
 
-        // Unlock skills when leaving SafeZone2 for the first time
         if (state.zone == 2 && !state.skillsUnlocked) {
             TextEffect.typeWriter("\nAs you step out of the Ruined Lab, a surge of power awakens within you...", 50);
-            TextEffect.typeWriter("Your class skills are now available! Use them in combat with the 'skill' command.\n", 50);
+            TextEffect.typeWriter("Your class skills are now available! Use them in combat with the 'skill' command.\n",
+                    50);
             state.skillsUnlocked = true;
         }
 
-        // Random statue encounter after Stage 1
-        if (checkStatueEncounter(state, zone, rand)) {
-            return; // statue event consumed the turn
-        }
+        if (checkStatueEncounter(state, zone, rand))
+            return;
 
-        // Boss gate and farming logic
-        if (state.forwardSteps >= 5) {
-            try {
-                if (!state.bossGateDiscovered) {
-                    // First time reaching the boss gate
-                    if (!BossGateSystem.canFightBoss(state, player, () -> {})) {
-                        TextEffect.typeWriter(
-                                "⛔ The boss gate remains sealed. You must grow stronger or craft the required weapon before you can face it.",
-                                60);
-                    } else {
-                        TextEffect.typeWriter(
-                                "🔥 You arrive at the boss gate. Type 'boss' when you are ready to challenge "
-                                        + zone.boss.getName() + ", or keep moving forward to farm mobs.",
-                                60);
-                    }
-                    state.bossGateDiscovered = true; // mark as discovered
+        try {
+            if (state.forwardSteps >= 5 && !state.bossGateDiscovered) {
+                if (!BossGateSystem.canFightBoss(state, player, () -> {
+                })) {
+                    TextEffect.typeWriter(
+                            "⛔ The boss gate remains sealed. You must grow stronger or craft the required weapon before you can face it.",
+                            60);
+                } else {
+                    TextEffect.typeWriter(
+                            "🔥 You arrive at the boss gate. New move options are available: farm, retreat, or challenge the boss.",
+                            60);
+
                 }
-
-                // Farming encounter (always happens when moving forward at/after the gate)
-                spawnMob(state, zone, player, rand);
-
-            } catch (Exception e) {
-                TextEffect.typeWriter("Something went wrong during the gate encounter.", 40);
-                System.err.println("Gate encounter error -> " + e.getMessage());
+                state.bossGateDiscovered = true;
             }
-        } else {
-            // Normal mob encounters before the gate
-            try {
-                spawnMob(state, zone, player, rand);
-            } catch (Exception e) {
-                TextEffect.typeWriter("Something went wrong during the encounter.", 40);
-                System.err.println("Mob encounter error -> " + e.getMessage());
-            }
+            spawnMob(state, zone, player, rand);
+        } catch (Exception e) {
+            TextEffect.typeWriter("Something went wrong during exploration.", 40);
+            System.err.println("Forward error -> " + e.getMessage());
         }
     }
 
     // --- Boss command ---
 
     private static void handleBoss(Player player, Scanner scanner, GameState state,
-                                   ZoneConfig zone, Runnable safeZoneAction) {
-        try {
-            if (state.forwardSteps >= 5) {
-                if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
-                    TextEffect.typeWriter(
-                            "⛔ The boss gate remains sealed. You must meet the requirements before you can fight.",
-                            60);
-                    return;
-                }
+            ZoneConfig zone, Runnable safeZoneAction, Random rand) {
+        if (state.forwardSteps < 5) {
+            TextEffect.typeWriter("🚪 You haven’t reached the boss gate yet. Keep moving forward.", 60);
+            return;
+        }
 
-                CombatSystem combat = new CombatSystem(state);
-                boolean win = combat.startCombat(player, zone.boss);
-                if (win) {
-                    TextEffect.typeWriter(
-                            "🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
-                    state.zone++;
-                    state.forwardSteps = 0;
-                    state.bossGateDiscovered = false; // reset for the next stage’s gate
-                    state.inSafeZone = true;
-                    safeZoneAction.run();
-                } else {
-                    TextEffect.typeWriter("You awaken back at the safe zone...", 60);
-                    state.inSafeZone = true;
-                    safeZoneAction.run();
-                }
+        try {
+            if (!state.bossGateDiscovered) {
+                // First encounter: fight or farm
+                TextEffect.typeWriter("🔥 You stand before the boss gate.\n1) Challenge Boss\n2) Farm", 60);
+                String choice = scanner.nextLine();
+                if (choice.equals("1"))
+                    startBossFight(player, state, zone, safeZoneAction);
+                else if (choice.equals("2")) {
+                    state.bossGateDiscovered = true;
+                    spawnMob(state, zone, player, rand);
+                } else
+                    TextEffect.typeWriter("Invalid choice. Enter 1 or 2.", 40);
             } else {
-                TextEffect.typeWriter("🚪 You haven’t reached the boss gate yet. Keep moving forward.", 60);
+                // After discovery: safe zone / farm / boss
+                TextEffect.typeWriter("Choose your action:\n1) Enter Safe Zone\n2) Farm\n3) Challenge Boss", 40);
+                String choice = scanner.nextLine();
+                switch (choice) {
+                    case "1":
+                        state.inSafeZone = true;
+                        safeZoneAction.run();
+                        break;
+                    case "2":
+                        spawnMob(state, zone, player, rand);
+                        break;
+                    case "3":
+                        if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
+                            TextEffect.typeWriter(
+                                    "⛔ The boss gate remains sealed. You must meet the requirements before you can fight.",
+                                    60);
+                        } else
+                            startBossFight(player, state, zone, safeZoneAction);
+                        break;
+                    default:
+                        TextEffect.typeWriter("Invalid choice. Enter 1, 2, or 3.", 40);
+                }
             }
         } catch (Exception e) {
             TextEffect.typeWriter("Something went wrong during the boss encounter.", 40);
-            System.err.println("Boss fight error -> " + e.getMessage());
+            System.err.println("Boss error -> " + e.getMessage());
+            state.inSafeZone = true;
+            safeZoneAction.run();
+        }
+    }
+
+    // --- Helper for boss fight outcome ---
+    private static void startBossFight(Player player, GameState state, ZoneConfig zone, Runnable safeZoneAction) {
+        CombatSystem combat = new CombatSystem(state);
+        boolean win = combat.startCombat(player, zone.boss);
+        if (win) {
+            TextEffect.typeWriter("🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+            state.zone++;
+            state.forwardSteps = 0;
+            state.bossGateDiscovered = false; // reset for next zone
+            state.inSafeZone = true;
+            safeZoneAction.run();
+        } else {
+            TextEffect.typeWriter("You awaken back at the safe zone...", 60);
             state.inSafeZone = true;
             safeZoneAction.run();
         }
@@ -176,7 +253,8 @@ public class ExplorationSystem {
     // --- Narration ---
 
     private static void narrateZoneExit(GameState state) {
-        if (state.forwardSteps != 1) return;
+        if (state.forwardSteps != 1)
+            return;
 
         switch (state.zone) {
             case 1:
@@ -205,7 +283,8 @@ public class ExplorationSystem {
     // --- Statue encounter ---
 
     private static boolean checkStatueEncounter(GameState state, ZoneConfig zone, Random rand) {
-        if (state.zone <= 1) return false; // only after Stage 1
+        if (state.zone <= 1)
+            return false; // only after Stage 1
         int chance = rand.nextInt(100);
         if (chance < 10) { // 10% chance per forward step
             Supporter statue = SupporterPool.getRandomSupporter(state.zone, rand);

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -41,6 +41,30 @@ public class ExplorationSystem {
                 state.inSafeZone = false;
                 state.forwardSteps++;
 
+                // 🆕 Safe zone exit narration (only once per zone)
+                if (state.forwardSteps == 1) {
+                    switch (state.zone) {
+                        case 1:
+                            TextEffect.typeWriter("\n🌌 You leave the safety of the School Rooftop behind...", 60);
+                            TextEffect.typeWriter("The path ahead winds through shattered classrooms and broken halls.", 60);
+                            TextEffect.typeWriter("Your goal: reach the next safe haven — the Ruined Lab.", 60);
+                            break;
+                        case 2:
+                            TextEffect.typeWriter("\n⚙️ You depart from the Ruined Lab, its broken machines fading into the distance...", 60);
+                            TextEffect.typeWriter("The road ahead twists through collapsed streets and burning wreckage.", 60);
+                            TextEffect.typeWriter("Your destination: the City Ruins, the next hub of survival.", 60);
+                            break;
+                        case 3:
+                            TextEffect.typeWriter("\n🏙️ You step out of the City Ruins, leaving behind its fragile refuge...", 60);
+                            TextEffect.typeWriter("The wasteland stretches before you, scarred by silence and danger.", 60);
+                            TextEffect.typeWriter("Your journey continues toward the next unknown landmark...", 60);
+                            break;
+                        default:
+                            TextEffect.typeWriter("\n🚶 You set out from the safe zone, heading toward your next destination.", 60);
+                            break;
+                    }
+                }
+
                 // Unlock skills when leaving SafeZone2 for the first time
                 if (state.zone == 2 && !state.skillsUnlocked) {
                     TextEffect.typeWriter(
@@ -104,6 +128,7 @@ public class ExplorationSystem {
                 } else {
                     try {
                         Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
+                        TextEffect.typeWriter("⚔️ A " + mob.getName() + " emerges from the shadows!", 60);
                         CombatSystem combat = new CombatSystem(state);
                         if (combat.startCombat(player, mob)) {
                             LootSystem.dropLoot(state);

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -236,8 +236,15 @@ public class ExplorationSystem {
     private static void startBossFight(Player player, GameState state, ZoneConfig zone, Runnable safeZoneAction) {
         CombatSystem combat = new CombatSystem(state);
         boolean win = combat.startCombat(player, zone.boss);
+
         if (win) {
             TextEffect.typeWriter("🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+
+            // 🆕 Trigger Sir Khai revival event after Zone 1 miniboss
+            if (state.zone == 1) {
+                handleMinibossDefeat(player, new Scanner(System.in), state);
+            }
+
             state.zone++;
             state.forwardSteps = 0;
             state.bossGateDiscovered = false; // reset for next zone
@@ -307,4 +314,40 @@ public class ExplorationSystem {
             LootSystem.dropLoot(state);
         }
     }
+
+    private static void handleMinibossDefeat(Player player, Scanner scanner, GameState state) {
+        // Award revival potion
+        state.revivalPotions++;
+        TextEffect.typeWriter("🏆 as you beat the fractured CITU logo! You obtained a Revival Potion.", 50);
+
+        // Narrative: Hallway encounter with Sir Khai
+        if (state.revivalPotions > 0) {
+            TextEffect.typeWriter(
+                    "You see a petrified statue of your teacher — Sir Khai, frozen mid-stance.", 50);
+            System.out.print("Do you want to use a Revival Potion to awaken him? (yes/no): ");
+            String choice = scanner.nextLine();
+
+            // Create Sir Khai supporter object
+            Supporter sirKhai = new Supporter("Sir Khai", "Mentor", "Guidance Heal");
+
+            if (choice.equalsIgnoreCase("yes")) {
+                state.revivalPotions--;
+                sirKhai.setRevived(true);
+                state.supporters.add(sirKhai);
+                TextEffect.typeWriter("✨ The stone shell crumbles away... Sir Khai opens his eyes.", 50);
+                TextEffect.typeWriter(
+                        "\"You’ve done well to come this far,\" he says. \"Allow me to guide you onward.\"", 50);
+            } else {
+                TextEffect.typeWriter(
+                        "You clutch the potion tightly and walk past the statue, leaving Sir Khai in silence...", 50);
+                // Force revival anyway
+                state.revivalPotions--;
+                sirKhai.setRevived(true);
+                state.supporters.add(sirKhai);
+                TextEffect.typeWriter(
+                        "⚠️ But destiny demands a guide... The potion glows and revives Sir Khai regardless.", 50);
+            }
+        }
+    }
+
 }

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -9,7 +9,7 @@ import rpg.utils.TextEffect;
 import rpg.game.GameState;
 import rpg.world.ZoneConfig;
 import rpg.world.WorldData;
-import rpg.world.SupporterPool; // 🆕 import the supporter pool
+import rpg.world.SupporterPool;
 
 public class ExplorationSystem {
 
@@ -21,156 +21,28 @@ public class ExplorationSystem {
             Runnable safeZoneAction) {
 
         try {
-            if (state.forwardSteps >= 5) {
-                TextEffect.typeWriter("Do you move backward, forward, or challenge the boss? (backward/forward/boss)",
-                        40);
-            } else {
-                TextEffect.typeWriter("Do you move backward or forward? (backward/forward)", 40);
-            }
-            System.out.print("> ");
-            String dir = scanner.nextLine();
-
             ZoneConfig zone = WorldData.getZone(state.zone);
             state.currentZoneBoss = zone.boss;
 
-            if (dir.equalsIgnoreCase("backward")) {
-                try {
-                    state.inSafeZone = true;
-                    safeZoneAction.run();
-                } catch (Exception e) {
-                    TextEffect.typeWriter("Something went wrong entering the safe zone.", 40);
-                    System.err.println("Safe zone error -> " + e.getMessage());
-                }
+            showPrompt(state);
+            System.out.print("> ");
+            String dir = scanner.nextLine();
 
-            } else if (dir.equalsIgnoreCase("forward")) {
-                state.inSafeZone = false;
-                state.forwardSteps++;
+            switch (dir.toLowerCase()) {
+                case "backward":
+                    handleBackward(state, safeZoneAction);
+                    break;
 
-                // 🆕 Safe zone exit narration (only once per zone)
-                if (state.forwardSteps == 1) {
-                    switch (state.zone) {
-                        case 1:
-                            TextEffect.typeWriter("\n🌌 You leave the safety of the School Rooftop behind...", 60);
-                            TextEffect.typeWriter("The path ahead winds through shattered classrooms and broken halls.",
-                                    60);
-                            TextEffect.typeWriter("Your goal: reach the next safe haven — the Ruined Lab.", 60);
-                            break;
-                        case 2:
-                            TextEffect.typeWriter(
-                                    "\n⚙️ You depart from the Ruined Lab, its broken machines fading into the distance...",
-                                    60);
-                            TextEffect.typeWriter(
-                                    "The road ahead twists through collapsed streets and burning wreckage.", 60);
-                            TextEffect.typeWriter("Your destination: the City Ruins, the next hub of survival.", 60);
-                            break;
-                        case 3:
-                            TextEffect.typeWriter(
-                                    "\n🏙️ You step out of the City Ruins, leaving behind its fragile refuge...", 60);
-                            TextEffect.typeWriter("The wasteland stretches before you, scarred by silence and danger.",
-                                    60);
-                            TextEffect.typeWriter("Your journey continues toward the next unknown landmark...", 60);
-                            break;
-                        default:
-                            TextEffect.typeWriter(
-                                    "\n🚶 You set out from the safe zone, heading toward your next destination.", 60);
-                            break;
-                    }
-                }
+                case "forward":
+                    handleForward(player, scanner, rand, state, zone);
+                    break;
 
-                // Unlock skills when leaving SafeZone2 for the first time
-                if (state.zone == 2 && !state.skillsUnlocked) {
-                    TextEffect.typeWriter(
-                            "\nAs you step out of the Ruined Lab, a surge of power awakens within you...", 50);
-                    TextEffect.typeWriter(
-                            "Your class skills are now available! Use them in combat with the 'skill' command.\n", 50);
-                    state.skillsUnlocked = true;
-                }
+                case "boss":
+                    handleBoss(player, scanner, state, zone, safeZoneAction);
+                    break;
 
-                // 🆕 Random statue encounter after Stage 1
-                if (state.zone > 1) { // only after Stage 1
-                    int chance = rand.nextInt(100);
-                    if (chance < 10) { // 10% chance per forward step
-                        Supporter statue = SupporterPool.getRandomSupporter(state.zone, rand);
-                        if (statue != null) {
-                            TextEffect.typeWriter("🗿 A mysterious statue appears in the "
-                                    + zone.name + "...", 60);
-                            ReviveSystem.randomRevive(state, statue);
-                            return;
-                        }
-                    }
-                }
-
-                if (state.forwardSteps >= 5) {
-                    try {
-                        if (!state.bossGateDiscovered) {
-                            // First time reaching the boss gate
-                            if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
-                                TextEffect.typeWriter(
-                                        "⛔ The boss gate remains sealed. You must grow stronger or craft the required weapon before you can face it.",
-                                        60);
-                            } else {
-                                TextEffect.typeWriter(
-                                        "🔥 You arrive at the boss gate. Type 'boss' when you are ready to challenge "
-                                                + zone.boss.getName() + ", or keep moving forward to farm mobs.",
-                                        60);
-                            }
-                            state.bossGateDiscovered = true; // mark as discovered
-                        }
-
-                        // Farming encounter (always happens when moving forward at/after the gate)
-                        Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
-                        TextEffect.typeWriter("⚔️ A " + mob.getName() + " prowls nearby!", 60);
-                        CombatSystem combat = new CombatSystem(state);
-                        if (combat.startCombat(player, mob)) {
-                            LootSystem.dropLoot(state);
-                        }
-                    } catch (Exception e) {
-                        TextEffect.typeWriter("Something went wrong during the gate encounter.", 40);
-                        System.err.println("Gate encounter error -> " + e.getMessage());
-                    }
-                } else {
-                    try {
-                        // Normal mob encounters before the gate
-                        Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
-                        TextEffect.typeWriter("⚔️ A " + mob.getName() + " emerges from the shadows!", 60);
-                        CombatSystem combat = new CombatSystem(state);
-                        if (combat.startCombat(player, mob)) {
-                            LootSystem.dropLoot(state);
-                        }
-                    } catch (Exception e) {
-                        TextEffect.typeWriter("Something went wrong during the encounter.", 40);
-                        System.err.println("Mob encounter error -> " + e.getMessage());
-                    }
-                }
-
-            } else if (dir.equalsIgnoreCase("boss")) {
-                // 🆕 new branch for boss fight
-                if (state.forwardSteps >= 5) {
-                    if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
-                        TextEffect.typeWriter(
-                                "⛔ The boss gate remains sealed. You must meet the requirements before you can fight.",
-                                60);
-                    } else {
-                        CombatSystem combat = new CombatSystem(state);
-                        boolean win = combat.startCombat(player, zone.boss);
-                        if (win) {
-                            TextEffect.typeWriter(
-                                    "🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
-                            state.zone++;
-                            state.forwardSteps = 0;
-                            state.inSafeZone = true;
-                            safeZoneAction.run();
-                        } else {
-                            TextEffect.typeWriter("You awaken back at the safe zone...", 60);
-                            state.inSafeZone = true;
-                            safeZoneAction.run();
-                        }
-                    }
-                } else {
-                    TextEffect.typeWriter("🚪 You haven’t reached the boss gate yet. Keep moving forward.", 60);
-                }
-            } else {
-                TextEffect.typeWriter("Invalid direction.", 40);
+                default:
+                    TextEffect.typeWriter("Invalid direction.", 40);
             }
 
         } catch (Exception e) {
@@ -179,6 +51,181 @@ public class ExplorationSystem {
         } finally {
             // Always runs after exploration attempt
             // Could be used for logging or ensuring state consistency
+        }
+    }
+
+    // --- Prompt ---
+
+    private static void showPrompt(GameState state) {
+        if (state.forwardSteps >= 5) {
+            TextEffect.typeWriter("Do you move backward, forward, or challenge the boss? (backward/forward/boss)", 40);
+        } else {
+            TextEffect.typeWriter("Do you move backward or forward? (backward/forward)", 40);
+        }
+    }
+
+    // --- Backward / Safe zone ---
+
+    private static void handleBackward(GameState state, Runnable safeZoneAction) {
+        try {
+            state.inSafeZone = true;
+            safeZoneAction.run();
+        } catch (Exception e) {
+            TextEffect.typeWriter("Something went wrong entering the safe zone.", 40);
+            System.err.println("Safe zone error -> " + e.getMessage());
+        }
+    }
+
+    // --- Forward / Exploration ---
+
+    private static void handleForward(Player player, Scanner scanner, Random rand,
+                                      GameState state, ZoneConfig zone) {
+        state.inSafeZone = false;
+        state.forwardSteps++;
+
+        // Narration on first step out of the safe zone for the current stage
+        narrateZoneExit(state);
+
+        // Unlock skills when leaving SafeZone2 for the first time
+        if (state.zone == 2 && !state.skillsUnlocked) {
+            TextEffect.typeWriter("\nAs you step out of the Ruined Lab, a surge of power awakens within you...", 50);
+            TextEffect.typeWriter("Your class skills are now available! Use them in combat with the 'skill' command.\n", 50);
+            state.skillsUnlocked = true;
+        }
+
+        // Random statue encounter after Stage 1
+        if (checkStatueEncounter(state, zone, rand)) {
+            return; // statue event consumed the turn
+        }
+
+        // Boss gate and farming logic
+        if (state.forwardSteps >= 5) {
+            try {
+                if (!state.bossGateDiscovered) {
+                    // First time reaching the boss gate
+                    if (!BossGateSystem.canFightBoss(state, player, () -> {})) {
+                        TextEffect.typeWriter(
+                                "⛔ The boss gate remains sealed. You must grow stronger or craft the required weapon before you can face it.",
+                                60);
+                    } else {
+                        TextEffect.typeWriter(
+                                "🔥 You arrive at the boss gate. Type 'boss' when you are ready to challenge "
+                                        + zone.boss.getName() + ", or keep moving forward to farm mobs.",
+                                60);
+                    }
+                    state.bossGateDiscovered = true; // mark as discovered
+                }
+
+                // Farming encounter (always happens when moving forward at/after the gate)
+                spawnMob(state, zone, player, rand);
+
+            } catch (Exception e) {
+                TextEffect.typeWriter("Something went wrong during the gate encounter.", 40);
+                System.err.println("Gate encounter error -> " + e.getMessage());
+            }
+        } else {
+            // Normal mob encounters before the gate
+            try {
+                spawnMob(state, zone, player, rand);
+            } catch (Exception e) {
+                TextEffect.typeWriter("Something went wrong during the encounter.", 40);
+                System.err.println("Mob encounter error -> " + e.getMessage());
+            }
+        }
+    }
+
+    // --- Boss command ---
+
+    private static void handleBoss(Player player, Scanner scanner, GameState state,
+                                   ZoneConfig zone, Runnable safeZoneAction) {
+        try {
+            if (state.forwardSteps >= 5) {
+                if (!BossGateSystem.canFightBoss(state, player, safeZoneAction)) {
+                    TextEffect.typeWriter(
+                            "⛔ The boss gate remains sealed. You must meet the requirements before you can fight.",
+                            60);
+                    return;
+                }
+
+                CombatSystem combat = new CombatSystem(state);
+                boolean win = combat.startCombat(player, zone.boss);
+                if (win) {
+                    TextEffect.typeWriter(
+                            "🏆 You defeated " + zone.boss.getName() + "! A new safe zone awaits...", 80);
+                    state.zone++;
+                    state.forwardSteps = 0;
+                    state.bossGateDiscovered = false; // reset for the next stage’s gate
+                    state.inSafeZone = true;
+                    safeZoneAction.run();
+                } else {
+                    TextEffect.typeWriter("You awaken back at the safe zone...", 60);
+                    state.inSafeZone = true;
+                    safeZoneAction.run();
+                }
+            } else {
+                TextEffect.typeWriter("🚪 You haven’t reached the boss gate yet. Keep moving forward.", 60);
+            }
+        } catch (Exception e) {
+            TextEffect.typeWriter("Something went wrong during the boss encounter.", 40);
+            System.err.println("Boss fight error -> " + e.getMessage());
+            state.inSafeZone = true;
+            safeZoneAction.run();
+        }
+    }
+
+    // --- Narration ---
+
+    private static void narrateZoneExit(GameState state) {
+        if (state.forwardSteps != 1) return;
+
+        switch (state.zone) {
+            case 1:
+                TextEffect.typeWriter("\n🌌 You leave the safety of the School Rooftop behind...", 60);
+                TextEffect.typeWriter("The path ahead winds through shattered classrooms and broken halls.", 60);
+                TextEffect.typeWriter("Your goal: reach the next safe haven — the Ruined Lab.", 60);
+                break;
+            case 2:
+                TextEffect.typeWriter(
+                        "\n⚙️ You depart from the Ruined Lab, its broken machines fading into the distance...", 60);
+                TextEffect.typeWriter("The road ahead twists through collapsed streets and burning wreckage.", 60);
+                TextEffect.typeWriter("Your destination: the City Ruins, the next hub of survival.", 60);
+                break;
+            case 3:
+                TextEffect.typeWriter(
+                        "\n🏙️ You step out of the City Ruins, leaving behind its fragile refuge...", 60);
+                TextEffect.typeWriter("The wasteland stretches before you, scarred by silence and danger.", 60);
+                TextEffect.typeWriter("Your journey continues toward the next unknown landmark...", 60);
+                break;
+            default:
+                TextEffect.typeWriter("\n🚶 You set out from the safe zone, heading toward your next destination.", 60);
+                break;
+        }
+    }
+
+    // --- Statue encounter ---
+
+    private static boolean checkStatueEncounter(GameState state, ZoneConfig zone, Random rand) {
+        if (state.zone <= 1) return false; // only after Stage 1
+        int chance = rand.nextInt(100);
+        if (chance < 10) { // 10% chance per forward step
+            Supporter statue = SupporterPool.getRandomSupporter(state.zone, rand);
+            if (statue != null) {
+                TextEffect.typeWriter("🗿 A mysterious statue appears in the " + zone.name + "...", 60);
+                ReviveSystem.randomRevive(state, statue);
+                return true; // event consumed the turn
+            }
+        }
+        return false;
+    }
+
+    // --- Mob spawning / farming ---
+
+    private static void spawnMob(GameState state, ZoneConfig zone, Player player, Random rand) {
+        Enemy mob = zone.mobs[rand.nextInt(zone.mobs.length)];
+        TextEffect.typeWriter("⚔️ A " + mob.getName() + " prowls nearby!", 60);
+        CombatSystem combat = new CombatSystem(state);
+        if (combat.startCombat(player, mob)) {
+            LootSystem.dropLoot(state);
         }
     }
 }

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -80,6 +80,11 @@ public class ExplorationSystem {
     private static void handleBackward(GameState state, Runnable safeZoneAction,
             ZoneConfig zone, Player player, Random rand) {
         try {
+
+            if (state.inSafeZone) {
+                TextEffect.typeWriter("You are already in the safe zone.", 50);
+                return;
+            }
             if (state.bossGateDiscovered) {
                 // After boss gate discovery → mostly safe retreat, but small chance of mob
                 int chance = rand.nextInt(100);
@@ -208,7 +213,7 @@ public class ExplorationSystem {
                     case "1":
                         if (state.inSafeZone) {
                             TextEffect.typeWriter("You are already in the safe zone.", 50);
-                            return; 
+                            return;
                         }
                         state.inSafeZone = true;
                         safeZoneAction.run();

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -188,6 +188,7 @@ public class ExplorationSystem {
 
     private static void handleBoss(Player player, Scanner scanner, GameState state,
             ZoneConfig zone, Runnable safeZoneAction, Random rand) {
+
         if (state.forwardSteps < 5) {
             TextEffect.typeWriter("🚪 You haven’t reached the boss gate yet. Keep moving forward.", 60);
             return;
@@ -195,18 +196,19 @@ public class ExplorationSystem {
 
         try {
             if (!state.bossGateDiscovered) {
-                // First encounter: fight or farm
+                // First time at the gate
                 TextEffect.typeWriter("🔥 You stand before the boss gate.\n1) Challenge Boss\n2) Farm", 60);
                 String choice = scanner.nextLine();
-                if (choice.equals("1"))
+                if (choice.equals("1")) {
                     startBossFight(player, state, zone, safeZoneAction);
-                else if (choice.equals("2")) {
+                } else if (choice.equals("2")) {
                     state.bossGateDiscovered = true;
                     spawnMob(state, zone, player, rand);
-                } else
+                } else {
                     TextEffect.typeWriter("Invalid choice. Enter 1 or 2.", 40);
+                }
             } else {
-                // After discovery: safe zone / farm / boss
+                // Gate already discovered → single menu
                 TextEffect.typeWriter("Choose your action:\n1) Run to Safe Zone\n2) Farm\n3) Challenge Boss", 40);
                 String choice = scanner.nextLine();
                 switch (choice) {
@@ -226,8 +228,9 @@ public class ExplorationSystem {
                             TextEffect.typeWriter(
                                     "⛔ The boss gate remains sealed. You must meet the requirements before you can fight.",
                                     60);
-                        } else
+                        } else {
                             startBossFight(player, state, zone, safeZoneAction);
+                        }
                         break;
                     default:
                         TextEffect.typeWriter("Invalid choice. Enter 1, 2, or 3.", 40);

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -202,7 +202,7 @@ public class ExplorationSystem {
                     TextEffect.typeWriter("Invalid choice. Enter 1 or 2.", 40);
             } else {
                 // After discovery: safe zone / farm / boss
-                TextEffect.typeWriter("Choose your action:\n1) Enter Safe Zone\n2) Farm\n3) Challenge Boss", 40);
+                TextEffect.typeWriter("Choose your action:\n1) Run to Safe Zone\n2) Farm\n3) Challenge Boss", 40);
                 String choice = scanner.nextLine();
                 switch (choice) {
                     case "1":

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -206,6 +206,10 @@ public class ExplorationSystem {
                 String choice = scanner.nextLine();
                 switch (choice) {
                     case "1":
+                        if (state.inSafeZone) {
+                            TextEffect.typeWriter("You are already in the safe zone.", 50);
+                            return; 
+                        }
                         state.inSafeZone = true;
                         safeZoneAction.run();
                         break;

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -23,7 +23,7 @@ public class SafeZoneSystem {
 
     public static void searchSafeZone(Player player, GameState state) {
         try {
-            TextEffect.typeWriter("You cannot search while in a Safe Zone. Try moving out first.", 60);
+            TextEffect.typeWriter("You found nothing, try moving out.", 60);
         } catch (Exception e) {
             TextEffect.typeWriter("You stumble while trying to search here.", 40);
             System.err.println("Safe zone search error -> " + e.getMessage());

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -9,7 +9,15 @@ import rpg.utils.TextEffect;
 
 public class SafeZoneSystem {
     public static void enterSafeZone(Player player, GameState state, Scanner scanner) {
+        // 🆕 Guard clause: prevent re-entering
+        if (state.inSafeZone) {
+            TextEffect.typeWriter("You are already in the safe zone.", 60);
+            return;
+        }
+
+        // Normal entry logic
         SafeZone zone = SafeZoneFactory.getZone(state.zone);
+        state.inSafeZone = true; // mark as inside
         zone.enter(player, state, scanner);
     }
 

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -9,11 +9,6 @@ import rpg.utils.TextEffect;
 
 public class SafeZoneSystem {
     public static void enterSafeZone(Player player, GameState state, Scanner scanner) {
-        // 🆕 Guard clause: prevent re-entering
-        if (state.inSafeZone) {
-            TextEffect.typeWriter("You are already in the safe zone.", 60);
-            return;
-        }
 
         // Normal entry logic
         SafeZone zone = SafeZoneFactory.getZone(state.zone);

--- a/src/rpg/systems/StatusSystem.java
+++ b/src/rpg/systems/StatusSystem.java
@@ -1,10 +1,11 @@
 package rpg.systems;
 
 import rpg.characters.Player;
+import rpg.game.GameState;
 import rpg.utils.TextEffect;
 
 public class StatusSystem {
-    public static void showStatus(Player player, int meat, int shards) {
+    public static void showStatus(Player player, int shards, GameState state) {
         TextEffect.typeWriter(
             "\n------ " + player.getName() + ": The " + player.getTrait() + " ------" +
             "\n| HP: " + player.getHp() + "/" + player.getMaxHp() +
@@ -14,9 +15,31 @@ public class StatusSystem {
             " | Defense: " + player.getDefense() +
             " | Intelligence: " + player.getIntelligence() +
             " | Weapon: " + (player.getWeapon() == null ? "None" : player.getWeapon().toString()) +
-            " | Shards: " + shards +          // ✅ only show shards
-            " | Meat: " + meat,               // ✅ keep meat
+            " | Shards: " + shards,
             40
         );
+
+        // 🆕 ASCII Progress Bar
+        int steps = state.forwardSteps;
+        int maxSteps = 5; // threshold for boss gate
+        StringBuilder bar = new StringBuilder("\nProgress: [S");
+
+        if (state.bossGateDiscovered) {
+            // Always show full bar once gate is found
+            for (int i = 0; i < maxSteps; i++) bar.append("#");
+            bar.append("B] Step ").append(maxSteps).append("/").append(maxSteps)
+               .append(" (Boss Gate Reached)");
+        } else {
+            for (int i = 0; i < maxSteps; i++) {
+                if (i < steps) bar.append("#");
+                else bar.append("-");
+            }
+            bar.append("B] Step ").append(steps).append("/").append(maxSteps);
+            if (steps == 0) {
+                bar.append(" (Safe Zone)");
+            }
+        }
+
+        TextEffect.typeWriter(bar.toString(), 40);
     }
 }

--- a/src/rpg/utils/TextEffect.java
+++ b/src/rpg/utils/TextEffect.java
@@ -1,18 +1,26 @@
 package rpg.utils;
 
+import rpg.game.GameState; // assuming you have a central state
+
 public class TextEffect {
 
-public static void typeWriter(String text, int delayMillis) {
-    for (char c : text.toCharArray()) {
-        System.out.print(c);
-        System.out.flush(); 
-        try {
-            Thread.sleep(delayMillis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+    public static void typeWriter(String text, int delayMillis) {
+        // 🆕 Fast mode check
+        if (GameState.current != null && GameState.current.fastMode) {
+            System.out.println(text);
+            return;
         }
-    }
-    System.out.println();
-}
 
+        // Normal typewriter effect
+        for (char c : text.toCharArray()) {
+            System.out.print(c);
+            System.out.flush();
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        System.out.println();
+    }
 }

--- a/src/rpg/utils/TextEffect.java
+++ b/src/rpg/utils/TextEffect.java
@@ -1,17 +1,13 @@
 package rpg.utils;
 
-import rpg.game.GameState; // assuming you have a central state
-
 public class TextEffect {
+    public static boolean fastMode = false; // 🆕 global toggle
 
     public static void typeWriter(String text, int delayMillis) {
-        // 🆕 Fast mode check
-        if (GameState.current != null && GameState.current.fastMode) {
+        if (fastMode) {
             System.out.println(text);
             return;
         }
-
-        // Normal typewriter effect
         for (char c : text.toCharArray()) {
             System.out.print(c);
             System.out.flush();

--- a/src/rpg/world/WorldData.java
+++ b/src/rpg/world/WorldData.java
@@ -8,33 +8,49 @@ public class WorldData {
         switch (zone) {
             case 1:
                 return new ZoneConfig(
-                        "School Rooftop", // name
-                        "The rooftop safe zone, overlooking the frozen campus.", // description
+                        "School Rooftop", // Safe Zone 1
+                        "The rooftop safe zone, overlooking the frozen campus.",
                         new Enemy[] {
                                 new Enemy("Stray Wolf", 40, 8, 12, 15),
                                 new Enemy("Feral Boar", 50, 10, 14, 18),
                                 new Enemy("Crystal-Scarred Crow", 45, 9, 13, 16),
                                 new Enemy("Lesser Crystal Golem", 60, 12, 16, 20)
                         },
-                        new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40),
+                        new Enemy("CITU Logo (Fractured)", 120, 15, 25, 40), // miniboss
                         new Weapon("Pencil Blade", 8, 12, 0.05, 1.5));
 
             case 2:
                 return new ZoneConfig(
-                        "Ruined Lab",
+                        "Ruined Lab", // Safe Zone 2
                         "Shattered corridors filled with failed experiments.",
                         new Enemy[] {
                                 new Enemy("Fractured Homunculus", 55, 10, 14, 20),
-                                new Enemy("Shattered Automaton", 80, 14, 20, 30)
+                                new Enemy("Shattered Automaton", 80, 14, 20, 30),
+                                new Enemy("Toxic Slime Residue", 65, 12, 18, 25)
                         },
-                        new Enemy("Aberrant Chimera", 180, 20, 30, 60),
+                        new Enemy("Aberrant Chimera", 180, 20, 30, 60), // boss
                         new Weapon("Prototype Blade", 12, 18, 0.08, 1.5));
+
+            case 3:
+                return new ZoneConfig(
+                        "City Ruins", // Safe Zone 3
+                        "Collapsed streets and burning wreckage, a fragile refuge among chaos.",
+                        new Enemy[] {
+                                new Enemy("Ash-Walker", 90, 18, 25, 35),
+                                new Enemy("Concrete Husk", 100, 20, 28, 40),
+                                new Enemy("Burnt Effigy", 85, 17, 24, 34)
+                        },
+                        new Enemy("Screaming Billboard", 220, 25, 35, 70), // boss
+                        new Weapon("Rebar Blade", 16, 24, 0.10, 1.6));
 
             default:
                 return new ZoneConfig(
-                        "Unknown Wasteland",
-                        "test",
-                        new Enemy[] { new Enemy("Shadow Spawn", 70, 15, 20, 30) },
+                        "Unknown Wasteland", // Zone 4 placeholder
+                        "A desolate expanse scarred by silence and danger.",
+                        new Enemy[] {
+                                new Enemy("Shadow Spawn", 70, 15, 20, 30),
+                                new Enemy("Ash Phantom", 95, 20, 28, 40)
+                        },
                         new Enemy("Ancient Horror", 250, 25, 35, 70),
                         null);
         }


### PR DESCRIPTION
## Summary

This PR introduces the **Exploration and Boss Gate System** and adds a developer‑only **DevSkip** toggle. Players can now move forward and backward through zones, encounter mobs, and discover boss gates. Safe zone logic has been refined with clear entry/exit handling, and boss encounters are streamlined to avoid duplicate prompts. DevSkip allows developers to skip typewriter delays for faster testing.

---

## Key Changes

- **ExplorationSystem.java**
  - Added `handleMove` with unified input handling (forward/backward before gate, numeric menu after gate discovery).
  - Refined `handleBackward`:
    - Guard clause prevents duplicate safe zone retreat messages.
    - Chance‑based mob encounters when retreating.
  - Refined `handleForward`:
    - Before gate discovery: step‑based exploration with narration and random encounters.
    - After gate discovery: forward becomes farming (mob spawn).
    - Boss gate discovery triggers tutorial messages and unlocks new options.
  - Refined `handleBoss`:
    - First‑time discovery: special 2‑option menu (Challenge Boss / Farm).
    - After discovery: consumes choice directly from exploration menu (no duplicate prompts).
    - Safe zone entry centralized via helper.
  - Added `enterSafeZone` helper for consistent safe zone logic.

- **GameState.java**
  - Tracks `forwardSteps`, `bossGateDiscovered`, and `inSafeZone`.
  - Added flags for zone progression and safe zone state.

- **CombatSystem.java**
  - Integrated with exploration: mobs spawn during forward/backward actions.
  - Boss fights triggered only when gate requirements are met.

- **ZoneConfig.java & WorldData.java**
  - Zones now include mobs and bosses for exploration/farming encounters.
  - Narration added for zone exits to improve immersion.

- **TextEffect.java**
  - Added global `devSkip` flag.
  - Developer commands `/devskip on` and `/devskip off` toggle instant text printing.
  - All typewriter calls respect the flag automatically.

---

## Impact

- **Player Experience**
  - Clearer progression: players must reach the boss gate before fighting.
  - Farming and retreat options available once gate is discovered.
  - Safe zone logic prevents duplicate retreat messages.
  - Narration enhances immersion when leaving safe zones.

- **Developer Experience**
  - DevSkip toggle (`/devskip on` / `/devskip off`) allows skipping typewriter delays for rapid testing.
  - No need to restart or rename characters to enable fast text.

- **System Reliability**
  - Input handling unified: no duplicate menus or missing prompts.
  - Error handling added to exploration methods for resilience.
  - Safe zone entry centralized for consistency.

---

## Changelog

- **Added**
  - DevSkip developer toggle (`/devskip on` / `/devskip off`).
  - Safe zone guard clause to prevent duplicate retreat messages.
  - Narration for zone exits.
- **Changed**
  - Exploration menus unified (no duplicate prompts).
  - Forward/backward logic refined for gate discovery and farming.
- **Fixed**
  - Boss gate menu duplication bug.
  - Retreat message duplication when already in safe zone.

---

## Next Steps for Team

- Extend exploration with environmental events (e.g., weather, ambient sounds).
- Add more narrative prompts for farming loops.
- Implement boss gate requirements (minimum level, crafted weapon).
- Integrate supporter assists during exploration (auto‑heal, buffs).
- Add developer shortcuts (`/forceBoss`, `/unlockRecipe`) for testing.

---

## Flow Visualization
[ExplorationSystem]
 ├─ handleMove
 │    ├─ before gate → forward/backward (step-based)
 │    └─ after gate → numeric menu (Safe Zone / Farm / Boss)
 ├─ handleForward
 │    ├─ increment steps
 │    ├─ narration + random encounters
 │    └─ discover boss gate at step 5
 ├─ handleBackward
 │    ├─ retreat logic
 │    ├─ chance mob encounter
 │    └─ safe zone entry
 └─ handleBoss
      ├─ first discovery → 2-option menu
      └─ after discovery → direct choice (Safe Zone / Farm / Boss)

[CombatSystem]
 ├─ startCombat (mob or boss)
 └─ returns win/lose

[TextEffect]
 ├─ typeWriter(text, delay)
 └─ respects fastMode flag (instant print if enabled)

[GameState]
 ├─ forwardSteps
 ├─ bossGateDiscovered
 ├─ inSafeZone
 └─ zone progression flags
