### PR TITLE
Supporter

### DIFF
--- a/src/rpg/characters/Player.java
+++ b/src/rpg/characters/Player.java
@@ -24,6 +24,8 @@ public class Player {
 
     // store base defense for resetting
     private int baseDefense;
+    // store base intelligence for temporary buffs
+    private int baseIntelligence;
 
     // Exp stats
     private int level;
@@ -75,6 +77,7 @@ public class Player {
         this.skills = new Skill[0];
 
         this.baseDefense = this.defense;
+        this.baseIntelligence = this.intelligence;
     }
 
     // 🆕 Unlock skills when reaching Level 2
@@ -225,6 +228,26 @@ public class Player {
         hp = maxHp;
         mana = maxMana;
         defense = baseDefense;
+    }
+
+    // Add temporary defense for the duration of a combat or event
+    public void addTemporaryDefense(int amount) {
+        this.defense += amount;
+    }
+
+    // Restore defense back to base value (use after combat)
+    public void resetDefense() {
+        this.defense = this.baseDefense;
+    }
+
+    // Add temporary intelligence for the duration of a combat or event
+    public void addTemporaryIntelligence(int amount) {
+        this.intelligence += amount;
+    }
+
+    // Restore intelligence back to base value
+    public void resetIntelligence() {
+        this.intelligence = this.baseIntelligence;
     }
 
     public boolean isAlive() {

--- a/src/rpg/characters/Supporter.java
+++ b/src/rpg/characters/Supporter.java
@@ -7,6 +7,7 @@ public class Supporter {
     private String ability;      // unique ability or buff they provide
     private int hp;              // optional: health if they can fight
     private int power;           // optional: support strength (buff/heal amount)
+    private boolean equipped;    // whether the player has equipped this supporter
 
     public Supporter(String name, String trait, String ability) {
         this.name = name;
@@ -15,6 +16,18 @@ public class Supporter {
         this.revived = false;
         this.hp = 100;   // default values, can be tuned
         this.power = 10;
+        this.equipped = false;
+    }
+
+    public Supporter(String name, String trait, String ability, SupporterRole role) {
+        this.name = name;
+        this.trait = trait;
+        this.ability = ability;
+        this.revived = false;
+        this.hp = 100;
+        this.power = 10;
+        this.equipped = false;
+        this.equipped = false;
     }
 
     // --- Getters ---
@@ -24,6 +37,11 @@ public class Supporter {
     public boolean isRevived() { return revived; }
     public int getHp() { return hp; }
     public int getPower() { return power; }
+    
+
+    public boolean isEquipped() { return equipped; }
+
+    public void setEquipped(boolean equipped) { this.equipped = equipped; }
 
     // --- Setters / State changes ---
     public void setRevived(boolean revived) {
@@ -39,6 +57,8 @@ public class Supporter {
 
     @Override
     public String toString() {
-        return (revived ? "✅ " : "❌ ") + name + " the " + trait + " (" + ability + ")";
+        String rev = revived ? "✅" : "❌";
+        String eq = equipped ? " [E]" : "";
+        return rev + " " + name + " the " + trait + " (" + ability + ")" + eq;
     }
 }

--- a/src/rpg/characters/SupporterRole.java
+++ b/src/rpg/characters/SupporterRole.java
@@ -1,0 +1,10 @@
+package rpg.characters;
+
+public enum SupporterRole {
+    MENTOR,
+    MEDIC,
+    GUARDIAN,
+    ATTACKER,
+    UTILITY,
+    GENERIC
+}

--- a/src/rpg/game/GameLoop.java
+++ b/src/rpg/game/GameLoop.java
@@ -29,13 +29,13 @@ public class GameLoop {
 
         while (running) {
             try {
-                // 🆕 Dynamic prompt - now includes "bag"
+                // 🆕 Dynamic prompt - now includes "bag" and "supporter"
                 if (state.inSafeZone) {
                     // ✅ Add shop option if zone > 1 (after defeating Zone 1 boss)
                     if (state.zone > 1) {
-                        System.out.print("> (craft / search / status / bag / shop / move): ");
+                        System.out.print("> (craft / search / status / bag / supporter / shop / move): ");
                     } else {
-                        System.out.print("> (craft / search / status / bag / move): ");
+                        System.out.print("> (craft / search / status / bag / supporter / move): ");
                     }
                 } else {
                     System.out.print("> (search / status / bag / move): ");
@@ -136,8 +136,31 @@ public class GameLoop {
                         }
                         break;
 
+                    case "supporter":
+                        try {
+                            rpg.systems.SafeZoneSystem.openSupporterMenu(player, state, scanner);
+                        } catch (Exception e) {
+                            TextEffect.typeWriter("Unable to open the supporter menu right now.", 40);
+                            System.err.println("Supporter menu error -> " + e.getMessage());
+                        }
+                        break;
+
                     case "move":
                         try {
+                            // Enforce at-least-one-equipped supporter only if the player has supporters
+                            if (state.inSafeZone && !state.supporters.isEmpty()) {
+                                boolean anyEquipped = false;
+                                for (rpg.characters.Supporter s : state.supporters) {
+                                    if (s.isEquipped()) { anyEquipped = true; break; }
+                                }
+                                if (!anyEquipped) {
+                                    TextEffect.typeWriter("You must equip at least one supporter before venturing out.", 50);
+                                    // Open supporter menu to let player equip
+                                    rpg.systems.SafeZoneSystem.openSupporterMenu(player, state, scanner);
+                                    break;
+                                }
+                            }
+
                             ExplorationSystem.handleMove(
                                     player, scanner, rand, state,
                                     () -> rpg.systems.SafeZoneSystem.enterSafeZone(player, state, scanner));

--- a/src/rpg/game/GameState.java
+++ b/src/rpg/game/GameState.java
@@ -35,6 +35,8 @@ public class GameState {
     public boolean shopUnlocked = false;
 
     public boolean zone2IntroShown = false;
+    // Track whether the player has seen the stage-2 supporter menu intro
+    public boolean supporterMenuIntroStage2Shown = false;
     public boolean skillsUnlocked = false;
 
     public boolean lootDisplayed = false; // ✅ already added, prevents duplicate loot text

--- a/src/rpg/safezones/RuinedLabSafeZone.java
+++ b/src/rpg/safezones/RuinedLabSafeZone.java
@@ -31,5 +31,6 @@ public class RuinedLabSafeZone implements SafeZone {
                 ShopSystem.openShop(state, scanner);
             }
         }
+        // RuinedLabSafeZone does not present the supporter menu here; use the global `supporter` command instead.
     }
 }

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -126,7 +126,7 @@ public class ExplorationSystem {
         // 🆕 If boss gate already discovered, forward becomes farm
         if (state.bossGateDiscovered) {
             // Allow statue encounters while farming (reuse same statue logic)
-            if (checkStatueEncounter(state, zone, rand)) return;
+            if (checkStatueEncounter(state, zone, rand, scanner)) return;
             spawnMob(state, zone, player, rand);
             return;
         }
@@ -135,7 +135,7 @@ public class ExplorationSystem {
         state.forwardSteps++;
         narrateZoneExit(state);
 
-        if (checkStatueEncounter(state, zone, rand))
+        if (checkStatueEncounter(state, zone, rand, scanner))
             return;
 
         try {
@@ -264,7 +264,7 @@ public class ExplorationSystem {
 
     // --- Statue encounter ---
 
-    private static boolean checkStatueEncounter(GameState state, ZoneConfig zone, Random rand) {
+    private static boolean checkStatueEncounter(GameState state, ZoneConfig zone, Random rand, java.util.Scanner scanner) {
         if (state.zone <= 1)
             return false; // only after Stage 1
         int chance = rand.nextInt(100);
@@ -272,7 +272,7 @@ public class ExplorationSystem {
             Supporter statue = SupporterPool.getRandomUnrevivedSupporter(state.zone, rand, state);
             if (statue != null) {
                 TextEffect.typeWriter("🗿 A mysterious statue appears in the " + zone.name + "...", 60);
-                ReviveSystem.randomRevive(state, statue);
+                ReviveSystem.randomRevive(state, statue, scanner);
                 return true; // event consumed the turn
             }
         }

--- a/src/rpg/systems/ExplorationSystem.java
+++ b/src/rpg/systems/ExplorationSystem.java
@@ -125,6 +125,8 @@ public class ExplorationSystem {
 
         // 🆕 If boss gate already discovered, forward becomes farm
         if (state.bossGateDiscovered) {
+            // Allow statue encounters while farming (reuse same statue logic)
+            if (checkStatueEncounter(state, zone, rand)) return;
             spawnMob(state, zone, player, rand);
             return;
         }
@@ -266,8 +268,8 @@ public class ExplorationSystem {
         if (state.zone <= 1)
             return false; // only after Stage 1
         int chance = rand.nextInt(100);
-        if (chance < 10) { // 10% chance per forward step
-            Supporter statue = SupporterPool.getRandomSupporter(state.zone, rand);
+        if (chance < 15) { // 15% chance per forward step (increased)
+            Supporter statue = SupporterPool.getRandomUnrevivedSupporter(state.zone, rand, state);
             if (statue != null) {
                 TextEffect.typeWriter("🗿 A mysterious statue appears in the " + zone.name + "...", 60);
                 ReviveSystem.randomRevive(state, statue);

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -47,24 +47,39 @@ public class ReviveSystem {
     }
 
     // Random statue revival outside safe zones
-    public static void randomRevive(GameState state, Supporter supporter) {
+    public static void randomRevive(GameState state, Supporter supporter, java.util.Scanner scanner) {
         try {
-            // If this supporter object is already revived or already in state, skip
             if (supporter == null) return;
             if (supporter.isRevived() || state.supporters.contains(supporter)) {
                 TextEffect.typeWriter("🗿 This statue has already been awakened.", 60);
                 return;
             }
 
-            if (state.revivalPotions > 0) {
-                state.revivalPotions--;
-                supporter.setRevived(true);
-                TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
-                if (!state.supporters.contains(supporter)) {
-                    state.supporters.add(supporter); // track revived allies
+            // Prompt the player whether to use a Revival Potion
+            TextEffect.typeWriter("A statue of " + supporter.getName() + " stands before you. Use a Revival Potion to awaken them? (yes/no)", 60);
+            System.out.print("> ");
+            String choice = "";
+            try {
+                choice = scanner.nextLine().trim().toLowerCase();
+            } catch (Exception e) {
+                // fallback: do not auto-revive
+                TextEffect.typeWriter("You decide not to disturb the statue.", 40);
+                return;
+            }
+
+            if (choice.equals("yes") || choice.equals("y")) {
+                if (state.revivalPotions > 0) {
+                    state.revivalPotions--;
+                    supporter.setRevived(true);
+                    TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
+                    if (!state.supporters.contains(supporter)) {
+                        state.supporters.add(supporter);
+                    }
+                } else {
+                    TextEffect.typeWriter("❌ You lack a Revival Potion. The statue remains silent.", 60);
                 }
             } else {
-                TextEffect.typeWriter("🗿 The statue remains silent... you lack a Revival Potion.", 60);
+                TextEffect.typeWriter("You leave the statue undisturbed.", 40);
             }
         } catch (Exception e) {
             TextEffect.typeWriter("An error occurred during statue revival.", 60);

--- a/src/rpg/systems/ReviveSystem.java
+++ b/src/rpg/systems/ReviveSystem.java
@@ -49,11 +49,20 @@ public class ReviveSystem {
     // Random statue revival outside safe zones
     public static void randomRevive(GameState state, Supporter supporter) {
         try {
+            // If this supporter object is already revived or already in state, skip
+            if (supporter == null) return;
+            if (supporter.isRevived() || state.supporters.contains(supporter)) {
+                TextEffect.typeWriter("🗿 This statue has already been awakened.", 60);
+                return;
+            }
+
             if (state.revivalPotions > 0) {
                 state.revivalPotions--;
                 supporter.setRevived(true);
                 TextEffect.typeWriter("✨ You used a Revival Potion to awaken " + supporter.getName() + "!", 60);
-                state.supporters.add(supporter); // track revived allies
+                if (!state.supporters.contains(supporter)) {
+                    state.supporters.add(supporter); // track revived allies
+                }
             } else {
                 TextEffect.typeWriter("🗿 The statue remains silent... you lack a Revival Potion.", 60);
             }

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -66,7 +66,14 @@ public class SafeZoneSystem {
                                 TextEffect.typeWriter("That supporter is not revived yet.", 40);
                                 break;
                             }
-                            s.setEquipped(!s.isEquipped());
+                            boolean newState = !s.isEquipped();
+                            if (newState) {
+                                // Unequip all others when equipping this one (single-equipped behavior)
+                                for (rpg.characters.Supporter other : state.supporters) {
+                                    if (other != null && other != s) other.setEquipped(false);
+                                }
+                            }
+                            s.setEquipped(newState);
                             TextEffect.typeWriter((s.isEquipped() ? "Equipped " : "Unequipped ") + s.getName(), 40);
                         } catch (NumberFormatException nfe) {
                             TextEffect.typeWriter("Invalid input.", 40);

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -24,4 +24,67 @@ public class SafeZoneSystem {
             System.err.println("Safe zone search error -> " + e.getMessage());
         }
     }
+
+    // Open supporter management menu (view and toggle equip)
+    public static void openSupporterMenu(Player player, GameState state, Scanner scanner) {
+        if (!state.inSafeZone) {
+            TextEffect.typeWriter("You must be inside a Safe Zone to manage supporters.", 40);
+            return;
+        }
+
+        if (state.supporters.isEmpty()) {
+            TextEffect.typeWriter("You have no supporters to manage.", 40);
+            return;
+        }
+
+        boolean done = false;
+        while (!done) {
+            try {
+                System.out.println();
+                TextEffect.typeWriter("Supporter Menu:\n1) View / Toggle Supporters\n0) Exit", 30);
+                System.out.print("> ");
+                String choice = scanner.nextLine().trim();
+
+                switch (choice) {
+                    case "1":
+                        for (int i = 0; i < state.supporters.size(); i++) {
+                            rpg.characters.Supporter s = state.supporters.get(i);
+                            TextEffect.typeWriter((i + 1) + ") " + s.toString(), 20);
+                        }
+                        TextEffect.typeWriter("0) Back", 20);
+                        System.out.print("> Toggle number: ");
+                        String sel = scanner.nextLine().trim();
+                        try {
+                            int idx = Integer.parseInt(sel);
+                            if (idx == 0) break;
+                            if (idx < 1 || idx > state.supporters.size()) {
+                                TextEffect.typeWriter("Invalid supporter number.", 40);
+                                break;
+                            }
+                            rpg.characters.Supporter s = state.supporters.get(idx - 1);
+                            if (!s.isRevived()) {
+                                TextEffect.typeWriter("That supporter is not revived yet.", 40);
+                                break;
+                            }
+                            s.setEquipped(!s.isEquipped());
+                            TextEffect.typeWriter((s.isEquipped() ? "Equipped " : "Unequipped ") + s.getName(), 40);
+                        } catch (NumberFormatException nfe) {
+                            TextEffect.typeWriter("Invalid input.", 40);
+                        }
+                        break;
+
+                    case "0":
+                        done = true;
+                        break;
+
+                    default:
+                        TextEffect.typeWriter("Invalid option.", 40);
+                }
+            } catch (Exception e) {
+                TextEffect.typeWriter("An error occurred in the supporter menu.", 40);
+                System.err.println("SafeZoneSystem.supporterMenu error -> " + e.getMessage());
+                done = true;
+            }
+        }
+    }
 }

--- a/src/rpg/systems/SafeZoneSystem.java
+++ b/src/rpg/systems/SafeZoneSystem.java
@@ -32,6 +32,16 @@ public class SafeZoneSystem {
             return;
         }
 
+        // Show a one-time Stage 2 intro the first time the player opens the supporter menu in Stage 2
+        try {
+            if (state.zone == 2 && !state.supporterMenuIntroStage2Shown) {
+                TextEffect.typeWriter("You notice weathered statues scattered outside the lab — echoes of people who once stood guard. You can awaken a statue using a Revival Potion (available from the shop for 6 shards). Revived Supporters follow you and lend short, practical aid in combat. After Sir Khai's arrival, more statues may appear while you explore. Equip one Supporter in a Safe Zone to enable their perk.", 60);
+                state.supporterMenuIntroStage2Shown = true;
+            }
+        } catch (Exception e) {
+            // non-fatal; continue to menu
+        }
+
         if (state.supporters.isEmpty()) {
             TextEffect.typeWriter("You have no supporters to manage.", 40);
             return;

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -3,6 +3,7 @@ package rpg.systems;
 import java.util.Random;
 import rpg.utils.TextEffect;
 import rpg.game.GameState;
+import rpg.world.SupporterPool;
 
 public class SearchSystem {
     private static Random rand = new Random();
@@ -30,6 +31,19 @@ public class SearchSystem {
                     TextEffect.typeWriter("✨ While searching, you uncover the " + recipe + " Recipe!", 60);
                 }
             }
+        }
+
+        // Small chance to stumble on a statue while searching (only meaningful outside zone 1)
+        try {
+            if (state.zone > 1 && rand.nextInt(100) < 12) { // 12% chance (increased)
+                rpg.characters.Supporter statue = SupporterPool.getRandomUnrevivedSupporter(state.zone, rand, state);
+                if (statue != null) {
+                    TextEffect.typeWriter("🗿 While searching, you notice a strange statue nearby...", 60);
+                    ReviveSystem.randomRevive(state, statue);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("SearchSystem.statueCheck error -> " + e.getMessage());
         }
     }
 }

--- a/src/rpg/systems/SearchSystem.java
+++ b/src/rpg/systems/SearchSystem.java
@@ -39,7 +39,8 @@ public class SearchSystem {
                 rpg.characters.Supporter statue = SupporterPool.getRandomUnrevivedSupporter(state.zone, rand, state);
                 if (statue != null) {
                     TextEffect.typeWriter("🗿 While searching, you notice a strange statue nearby...", 60);
-                    ReviveSystem.randomRevive(state, statue);
+                    java.util.Scanner scanner = new java.util.Scanner(System.in);
+                    ReviveSystem.randomRevive(state, statue, scanner);
                 }
             }
         } catch (Exception e) {

--- a/src/rpg/systems/ShopSystem.java
+++ b/src/rpg/systems/ShopSystem.java
@@ -18,11 +18,20 @@ public class ShopSystem {
         try {
             TextEffect.typeWriter("🛒 Welcome to my shop! What would you like to buy?", 50);
 
-            // Show inventory
+            // Show basic items
+            final int REVIVAL_PRICE = 6;
+            final int CRYSTAL_PRICE = 10;
+
+            int menuIndex = 1;
+            TextEffect.typeWriter((menuIndex++) + ". Revival Potion (" + REVIVAL_PRICE + " Shards)", 40);
+            TextEffect.typeWriter((menuIndex++) + ". Crystal (" + CRYSTAL_PRICE + " Shards)", 40);
+
+            // Show blueprints after basic items
             for (int i = 0; i < inventory.size(); i++) {
                 Blueprint bp = inventory.get(i);
-                TextEffect.typeWriter((i + 1) + ". " + bp.getName() + " (" + bp.getPrice() + " Shards)", 40);
+                TextEffect.typeWriter((menuIndex++) + ". " + bp.getName() + " (" + bp.getPrice() + " Shards)", 40);
             }
+
             TextEffect.typeWriter("0. Leave shop", 40);
 
             System.out.print("> ");
@@ -34,9 +43,31 @@ public class ShopSystem {
                     TextEffect.typeWriter("You leave the shop.", 40);
                     return;
                 }
+                // Map menu number to action
+                int base = 1;
+                int revivalOption = base; base++;
+                int crystalOption = base; base++;
+                int firstBlueprintOption = base; // maps to inventory.get(0)
 
-                if (option > 0 && option <= inventory.size()) {
-                    Blueprint selected = inventory.get(option - 1);
+                if (option == revivalOption) {
+                    if (state.shards >= REVIVAL_PRICE) {
+                        state.shards -= REVIVAL_PRICE;
+                        state.revivalPotions += 1;
+                        TextEffect.typeWriter("You bought a Revival Potion. You now have " + state.revivalPotions + ".", 60);
+                    } else {
+                        TextEffect.typeWriter("You don’t have enough shards.", 60);
+                    }
+                } else if (option == crystalOption) {
+                    if (state.shards >= CRYSTAL_PRICE) {
+                        state.shards -= CRYSTAL_PRICE;
+                        state.crystals += 1;
+                        TextEffect.typeWriter("You bought a Crystal. You now have " + state.crystals + " crystals.", 60);
+                    } else {
+                        TextEffect.typeWriter("You don’t have enough shards.", 60);
+                    }
+                } else if (option >= firstBlueprintOption && option < firstBlueprintOption + inventory.size()) {
+                    int idx = option - firstBlueprintOption;
+                    Blueprint selected = inventory.get(idx);
 
                     if (state.shards >= selected.getPrice()) {
                         state.shards -= selected.getPrice();

--- a/src/rpg/systems/SupporterSystem.java
+++ b/src/rpg/systems/SupporterSystem.java
@@ -1,0 +1,147 @@
+package rpg.systems;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Random;
+import rpg.characters.Supporter;
+import rpg.characters.Player;
+import rpg.characters.Enemy;
+import rpg.game.GameState;
+import rpg.utils.TextEffect;
+
+/**
+ * Encapsulates per-combat supporter behaviors and state (cooldowns/durations).
+ * Keeps CombatSystem focused and makes supporter logic extensible.
+ */
+public class SupporterSystem {
+
+    private final Map<Supporter, SupporterCombatState> combatState = new ConcurrentHashMap<>();
+
+    private static class SupporterCombatState {
+        int inspireRemaining = 0;
+        int defRemaining = 0;
+        int cooldown = 0;
+    }
+
+    public SupporterSystem() {
+    }
+
+    // Called once at combat start to apply start-of-combat buffs
+    public void applyStartOfCombat(GameState state, Player player) {
+        try {
+            if (state.supporters == null) return;
+            for (Supporter s : state.supporters) {
+                if (s == null || !s.isRevived() || !s.isEquipped()) continue;
+
+                // ensure a combat state exists
+                combatState.putIfAbsent(s, new SupporterCombatState());
+
+                // For the small unique set of supporters we check by name/trait
+                String lname = s.getName() == null ? "" : s.getName().toLowerCase();
+                if (lname.contains("sir khai") || lname.contains("khai")) {
+                    TextEffect.typeWriter(s.getName() + " offers guidance from the sidelines — you feel steadier. (DEF +5 for this fight)", 40);
+                    player.addTemporaryDefense(5);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("SupporterSystem.applyStartOfCombat error -> " + e.getMessage());
+        }
+    }
+
+    // Called each round (from CombatSystem) to let supporters act
+    public void performSupporterTurns(GameState state, Player player, Enemy enemy, int turnCount, Random rand) {
+        try {
+            if (state.supporters == null) return;
+            for (Supporter s : state.supporters) {
+                if (s == null || !s.isRevived() || !s.isEquipped()) continue;
+
+                SupporterCombatState st = combatState.computeIfAbsent(s, k -> new SupporterCombatState());
+
+                int speakChance = 30; // percent
+
+                // Use name/ability-based unique supporter behaviors for the small fixed set
+                String lname = s.getName() == null ? "" : s.getName().toLowerCase();
+                if (lname.contains("sir khai") || lname.contains("khai")) {
+                    String[] khaiLines = new String[] {
+                        "Sir Khai: 'Breathe, and strike with purpose.'",
+                        "Sir Khai: 'Focus your mind, not just your fists.'",
+                        "Sir Khai: 'Small steps, steady hands.'",
+                        "Sir Khai: 'Remember why you started.'"
+                    };
+                    if (rand.nextInt(100) < speakChance) TextEffect.typeWriter(khaiLines[rand.nextInt(khaiLines.length)], 25);
+
+                    if (st.inspireRemaining == 0 && turnCount % 3 == 0 && rand.nextInt(100) < 40) {
+                        TextEffect.typeWriter("✨ The air stills as " + s.getName() + " steps forward.", 40);
+                        TextEffect.typeWriter(s.getName() + " intones: 'Center yourself — clarity follows.'", 40);
+                        TextEffect.typeWriter("A warm clarity fills your head. You feel sharper. (INT +3 for 2 turns)", 40);
+                        player.addTemporaryIntelligence(3);
+                        st.inspireRemaining = 2;
+                    }
+                } else if (lname.contains("dean")) {
+                    String[] deanLines = new String[] {
+                        "Ma'am Dean: 'Stay disciplined — control the fight.'",
+                        "Ma'am Dean: 'Maintain your stance!'",
+                        "Ma'am Dean: 'Don't let your guard drop.'"
+                    };
+                    if (rand.nextInt(100) < speakChance) TextEffect.typeWriter(deanLines[rand.nextInt(deanLines.length)], 25);
+
+                    if (st.defRemaining == 0 && turnCount % 4 == 0 && rand.nextInt(100) < 30) {
+                        TextEffect.typeWriter(s.getName() + " barks an order — you plant your feet. (+DEF +4 for 1 turn)", 40);
+                        player.addTemporaryDefense(4);
+                        st.defRemaining = 1;
+                    }
+                } else if (lname.contains("canteen") || (s.getTrait() != null && s.getTrait().toLowerCase().contains("merchant")) || lname.contains("kael")) {
+                    String[] canteenLines = new String[] {
+                        "Canteen Staff: 'You need energy? I've got something warm.'",
+                        "Canteen Staff: 'Eat up — this'll keep you going.'",
+                        "Canteen Staff: 'A little snack goes a long way.'"
+                    };
+                    if (rand.nextInt(100) < speakChance) TextEffect.typeWriter(canteenLines[rand.nextInt(canteenLines.length)], 25);
+
+                    if (st.cooldown == 0 && player.getHp() < player.getMaxHp() && rand.nextInt(100) < 25) {
+                        int healAmt = 3 + rand.nextInt(3); // 3-5
+                        player.heal(healAmt);
+                        TextEffect.typeWriter(s.getName() + " slips you a snack and heals " + healAmt + " HP.", 40);
+                        st.cooldown = 2;
+                    }
+                } else {
+                    String[] genericLines = new String[] {
+                        s.getName() + ": 'I'm here if you need me.'",
+                        s.getName() + ": 'Standing by.'",
+                        s.getName() + ": 'I've got your back.'"
+                    };
+                    if (rand.nextInt(100) < speakChance) TextEffect.typeWriter(genericLines[rand.nextInt(genericLines.length)], 20);
+                }
+            }
+
+            // After processing all supporters this turn, decrement their timers
+            decrementSupporterStates();
+
+        } catch (Exception e) {
+            System.err.println("SupporterSystem.performSupporterTurns error -> " + e.getMessage());
+        }
+    }
+
+    private void decrementSupporterStates() {
+        for (Map.Entry<Supporter, SupporterCombatState> entry : combatState.entrySet()) {
+            SupporterCombatState st = entry.getValue();
+            if (st.inspireRemaining > 0) {
+                st.inspireRemaining--;
+            }
+            if (st.defRemaining > 0) st.defRemaining--;
+            if (st.cooldown > 0) st.cooldown--;
+        }
+    }
+
+    // Reset buffs and clear per-combat state
+    public void resetAfterCombat(Player player) {
+        try {
+            // Clear temporary intelligence and defense
+            player.resetIntelligence();
+            player.resetDefense();
+            combatState.clear();
+        } catch (Exception e) {
+            System.err.println("SupporterSystem.resetAfterCombat error -> " + e.getMessage());
+        }
+    }
+}

--- a/src/rpg/systems/SupporterSystem.java
+++ b/src/rpg/systems/SupporterSystem.java
@@ -30,6 +30,18 @@ public class SupporterSystem {
     public void applyStartOfCombat(GameState state, Player player) {
         try {
             if (state.supporters == null) return;
+            // Ensure only one supporter is equipped — defensive guard in case other code set multiple
+            boolean seenEquipped = false;
+            for (Supporter sCheck : state.supporters) {
+                if (sCheck == null) continue;
+                if (sCheck.isEquipped()) {
+                    if (!seenEquipped) {
+                        seenEquipped = true;
+                    } else {
+                        sCheck.setEquipped(false);
+                    }
+                }
+            }
             for (Supporter s : state.supporters) {
                 if (s == null || !s.isRevived() || !s.isEquipped()) continue;
 

--- a/src/rpg/world/SupporterPool.java
+++ b/src/rpg/world/SupporterPool.java
@@ -9,23 +9,22 @@ public class SupporterPool {
     private static final Map<Integer, List<Supporter>> pool = new HashMap<>();
 
     static {
-        // Stage 1 – School Rooftop
+        // Stage 1 – School Rooftop (only Sir Khai; others introduced later)
         pool.put(1, Arrays.asList(
-            new Supporter("Sir Khai", "Teacher", "Guidance"), // scripted, but kept here for consistency
-            new Supporter("Aya", "Strategist", "Encouragement")
+            new Supporter("Sir Khai", "Teacher", "Guidance") // scripted, kept
         ));
 
         // Stage 2 – Ruined Lab
         pool.put(2, Arrays.asList(
-            new Supporter("Lira", "Scientist", "Chemical Aid"),
-            new Supporter("Ryo", "Inventor", "Repair")
+            new Supporter("School Security Guard", "Guardian", "Protect"),
+            new Supporter("Canteen Staff", "Merchant", "Snack Aid"),
+            new Supporter("Ma'am Dean", "Discipline", "Command")
         ));
 
         // Stage 3 – City Ruins
         pool.put(3, Arrays.asList(
-            new Supporter("Hana", "Medic", "First Aid"),
-            new Supporter("Daisuke", "Guardian", "Shield Wall"),
-            new Supporter("Kael", "Merchant", "Resourceful")
+            new Supporter("Jeepney Philosopher", "Philosopher", "Musing"),
+            new Supporter("Mr. CodeChum", "Coder", "Debug")
         ));
     }
 

--- a/src/rpg/world/SupporterPool.java
+++ b/src/rpg/world/SupporterPool.java
@@ -1,7 +1,9 @@
 package rpg.world;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import rpg.characters.Supporter;
+import rpg.game.GameState;
 
 public class SupporterPool {
     private static final Map<Integer, List<Supporter>> pool = new HashMap<>();
@@ -31,5 +33,27 @@ public class SupporterPool {
         List<Supporter> supporters = pool.get(zone);
         if (supporters == null || supporters.isEmpty()) return null;
         return supporters.get(rand.nextInt(supporters.size()));
+    }
+
+    // Return a random supporter from the pool that hasn't already been revived (by instance or name)
+    public static Supporter getRandomUnrevivedSupporter(int zone, Random rand, GameState state) {
+        List<Supporter> supporters = pool.get(zone);
+        if (supporters == null || supporters.isEmpty()) return null;
+
+        List<Supporter> candidates = supporters.stream()
+            .filter(s -> s != null)
+            .filter(s -> !s.isRevived())
+            .filter(s -> {
+                // also check by name against state.supporters to catch scripted/new instances
+                for (Supporter ss : state.supporters) {
+                    if (ss != null && ss.getName() != null && s.getName() != null && ss.getName().equalsIgnoreCase(s.getName()))
+                        return false;
+                }
+                return true;
+            })
+            .collect(Collectors.toList());
+
+        if (candidates.isEmpty()) return null;
+        return candidates.get(rand.nextInt(candidates.size()));
     }
 }


### PR DESCRIPTION
Implemented equipable Supporters and integrated them into core game flows. Players can manage supporters from a global Supporter menu in safe zones (single equip enforced). Supporters now have combat roles handled by a new SupporterSystem (start-of-combat buffs and periodic actions). Statue revivals now prompt players to consume Revival Potions (no auto-revive) and revived supporters are filtered from future encounters. Added Revival Potion (6 shards) and Crystal (10 shards) to the shop. Reduced the Supporter pool to a small set of named characters by zone. Increased statue spawn chances and enabled statue spawns during farm mode and searches. Defensive checks were added to avoid duplicate revives. See file-by-file diff for implementation details.